### PR TITLE
Fix RNTO privesc and  chmod path validation

### DIFF
--- a/etc/permissions.yml
+++ b/etc/permissions.yml
@@ -304,6 +304,15 @@ rules:
 
 
   # ---------------------------------------------------------------------------
+  # SITE CHMOD. This is checked per-path in addition to the sitecmd CHMOD
+  # gate above; without a matching rule here CHMOD defaults to siteop-only.
+  # ---------------------------------------------------------------------------
+  chmod:
+    - path: /*
+      required: $siteop
+
+
+  # ---------------------------------------------------------------------------
   # Nuke and unnuke
   # ---------------------------------------------------------------------------
   nuke:

--- a/internal/core/commands.go
+++ b/internal/core/commands.go
@@ -802,14 +802,22 @@ func (s *Session) processCommand(cmd string, args []string, tlsConfig *tls.Confi
 		}
 		fromPath := path.Join(s.CurrentDir, s.RenameFrom)
 		toPath := path.Join(s.CurrentDir, args[0])
+		// toDir/toName must be derived from the already-cleaned toPath, not the
+		// raw client argument: path.Join above roots and collapses ".." so the
+		// resulting toName can never smuggle a traversal sequence past the
+		// slave's destination-directory jail.
+		toDir := path.Dir(toPath)
+		toName := path.Base(toPath)
+		if toName == "" || toName == "." || toName == "/" || toName == ".." {
+			fmt.Fprintf(s.Conn, "501 Invalid destination name.\r\n")
+			return false
+		}
 		if !s.canRenamePath(fromPath, toPath) {
 			fmt.Fprintf(s.Conn, "550 Access Denied: Insufficient flags.\r\n")
 			return false
 		}
 		if s.Config.Mode == "master" && s.MasterManager != nil {
 			if bridge, ok := s.MasterManager.(MasterBridge); ok {
-				toDir := s.CurrentDir
-				toName := args[0]
 				fromRelease := path.Clean(path.Dir(fromPath))
 				previousMedia := cloneStringMap(bridge.GetDirMediaInfo(fromRelease))
 				if err := bridge.RenameFile(fromPath, toDir, toName); err != nil {

--- a/internal/core/owner_acl.go
+++ b/internal/core/owner_acl.go
@@ -48,6 +48,13 @@ func (s *Session) canRenamePath(fromPath, toPath string) bool {
 	if !s.ACLEngine.CanPerform(s.User, "RENAMEOWN", fromACLPath) {
 		return false
 	}
+	// RENAMEOWN only grants renaming files the user owns; the destination
+	// still has to be somewhere the user is generally allowed to place a
+	// renamed file, otherwise an owned-file rename can land anywhere ACLed
+	// paths would otherwise forbid.
+	if !s.ACLEngine.CanPerform(s.User, "RENAMEOWN", toACLPath) {
+		return false
+	}
 	return s.pathOwnedByUser(fromPath)
 }
 

--- a/internal/core/owner_acl_test.go
+++ b/internal/core/owner_acl_test.go
@@ -1,0 +1,57 @@
+package core
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"weaveftpd/internal/acl"
+	"weaveftpd/internal/user"
+)
+
+// TestCanRenamePathEnforcesDestinationACL guards against the RNTO privilege
+// escalation where a user who owns a file could RENAMEOWN it to any
+// destination because only the source path was ACL-checked. A restrictive
+// config here scopes renameown to /incoming/* only; a user owning a file
+// under /incoming must not be able to rename it out to /private/*.
+func TestCanRenamePathEnforcesDestinationACL(t *testing.T) {
+	dir := t.TempDir()
+	aclPath := filepath.Join(dir, "permissions.yml")
+	if err := os.WriteFile(aclPath, []byte(`
+roles:
+  anyone:
+    anyone: true
+  siteop:
+    all_flags: ["1"]
+
+rules:
+  rename:
+    - path: /*
+      required: $siteop
+
+  renameown:
+    - path: /incoming/*
+      required: $anyone
+    - path: /*
+      required: $siteop
+`), 0o644); err != nil {
+		t.Fatalf("write %s: %v", aclPath, err)
+	}
+
+	engine, err := acl.LoadEngine(aclPath)
+	if err != nil {
+		t.Fatalf("LoadEngine() error = %v", err)
+	}
+
+	s := &Session{
+		Config:    &Config{ACLBasePath: "/"},
+		ACLEngine: engine,
+		User:      &user.User{Name: "leech"},
+	}
+
+	// Owns the source file but destination sits outside the renameown-scoped
+	// subtree; must be denied even though the user owns the source.
+	if s.canRenamePath("/incoming/file.txt", "/private/file.txt") {
+		t.Fatal("expected rename to a destination outside the renameown scope to be denied")
+	}
+}

--- a/internal/core/site_misc.go
+++ b/internal/core/site_misc.go
@@ -3,6 +3,7 @@ package core
 import (
 	"fmt"
 	"os"
+	"path"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -18,9 +19,26 @@ func (s *Session) HandleSiteChmod(args []string) bool {
 		fmt.Fprintf(s.Conn, "501 Invalid mode (use octal, e.g. 755).\r\n")
 		return false
 	}
-	fullPath := filepath.Join(s.Config.StoragePath, s.CurrentDir, args[1])
-	// Note: in master/slave mode the file lives on a slave, so a chmod on the
-	// master path will fail and correctly report 550 rather than a false success.
+	// vpath is rooted and cleaned by path.Join, so it can never carry a ".."
+	// that escapes the virtual root, unlike a bare filepath.Join of the raw
+	// client argument against the real storage path.
+	vpath := path.Join(s.CurrentDir, args[1])
+	aclPath := path.Join(s.Config.ACLBasePath, vpath)
+	if s.ACLEngine == nil || !s.ACLEngine.CanPerform(s.User, "CHMOD", aclPath) {
+		fmt.Fprintf(s.Conn, "550 Access Denied: Insufficient flags.\r\n")
+		return false
+	}
+	if s.Config.Mode == "master" && s.MasterManager != nil {
+		if bridge, ok := s.MasterManager.(MasterBridge); ok {
+			if err := bridge.Chmod(vpath, uint32(mode)); err != nil {
+				fmt.Fprintf(s.Conn, "550 CHMOD failed: %v\r\n", err)
+				return false
+			}
+			fmt.Fprintf(s.Conn, "200 SITE CHMOD successful.\r\n")
+			return false
+		}
+	}
+	fullPath := filepath.Join(s.Config.StoragePath, filepath.FromSlash(strings.TrimPrefix(vpath, "/")))
 	if err := os.Chmod(fullPath, os.FileMode(mode)); err != nil {
 		fmt.Fprintf(s.Conn, "550 CHMOD failed: %v\r\n", err)
 		return false

--- a/internal/slave/rename_security_test.go
+++ b/internal/slave/rename_security_test.go
@@ -1,0 +1,81 @@
+package slave
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"weaveftpd/internal/protocol"
+)
+
+// TestHandleRenameRejectsTraversalInToName guards against the RNTO privilege
+// escalation where an unsanitized toName (destination filename) containing
+// "../" sequences could escape the storage root via a bare filepath.Join.
+func TestHandleRenameRejectsTraversalInToName(t *testing.T) {
+	siteRoot := t.TempDir()
+	outsideDir := t.TempDir()
+
+	srcPath := filepath.Join(siteRoot, "incoming", "file.txt")
+	if err := os.MkdirAll(filepath.Dir(srcPath), 0o755); err != nil {
+		t.Fatalf("mkdir source dir: %v", err)
+	}
+	if err := os.WriteFile(srcPath, []byte("payload"), 0o644); err != nil {
+		t.Fatalf("write source file: %v", err)
+	}
+
+	s := &Slave{
+		roots: []MountedRoot{{Path: siteRoot, MountPath: "/"}},
+	}
+
+	// Compute how many "../" hops are needed to reach outsideDir from the
+	// resolved destination directory, mirroring what a malicious client
+	// would send as the RNTO argument.
+	rel, err := filepath.Rel(siteRoot, outsideDir)
+	if err != nil {
+		t.Fatalf("filepath.Rel: %v", err)
+	}
+	maliciousToName := filepath.ToSlash(filepath.Join(rel, "escaped.txt"))
+
+	resp := s.handleRename(&protocol.AsyncCommand{
+		Index: "rename-1",
+		Args:  []string{"/incoming/file.txt", "/incoming", maliciousToName},
+	})
+
+	errResp, ok := resp.(*protocol.AsyncResponseError)
+	if !ok {
+		t.Fatalf("expected traversal attempt to be rejected, got %T: %#v", resp, resp)
+	}
+	if errResp.Message == "" {
+		t.Fatalf("expected non-empty error message")
+	}
+
+	if _, err := os.Stat(filepath.Join(outsideDir, "escaped.txt")); err == nil {
+		t.Fatalf("file escaped storage root to %s", outsideDir)
+	}
+	if _, err := os.Stat(srcPath); err != nil {
+		t.Fatalf("expected source file to remain in place after rejected rename: %v", err)
+	}
+}
+
+func TestMountedRootContains(t *testing.T) {
+	root := MountedRoot{Path: "/data/site"}
+
+	cases := []struct {
+		name string
+		path string
+		want bool
+	}{
+		{"exact root", "/data/site", true},
+		{"child path", "/data/site/incoming/file.txt", true},
+		{"escaped via traversal", "/data/site/../../etc/passwd", false},
+		{"sibling directory", "/data/site2/file.txt", false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := root.contains(tc.path); got != tc.want {
+				t.Fatalf("contains(%q) = %v, want %v", tc.path, got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/slave/slave.go
+++ b/internal/slave/slave.go
@@ -255,6 +255,23 @@ func (r MountedRoot) virtualPath(fullPath string) (string, bool) {
 	return cleanVirtualPath(path.Join(r.MountPath, filepath.ToSlash(rel))), true
 }
 
+// contains reports whether fullPath resolves to a location inside r.Path.
+// Used as a last-line defense against a destination that escapes the root
+// via a raw filepath.Join, independent of whether the virtual path that
+// produced it was properly jailed upstream.
+func (r MountedRoot) contains(fullPath string) bool {
+	cleanRoot := filepath.Clean(r.Path)
+	cleanFull := filepath.Clean(fullPath)
+	if cleanFull == cleanRoot {
+		return true
+	}
+	rel, err := filepath.Rel(cleanRoot, cleanFull)
+	if err != nil || rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+		return false
+	}
+	return true
+}
+
 func (s *Slave) rootsForVirtualPath(virtualPath string) []MountedRoot {
 	virtualPath = cleanVirtualPath(virtualPath)
 	matches := make([]MountedRoot, 0, len(s.roots))
@@ -744,6 +761,9 @@ func (s *Slave) handleRename(ac *protocol.AsyncCommand) interface{} {
 	}
 	toDirPath := destRoot.fullPath(toDir)
 	toPath := filepath.Join(toDirPath, toName)
+	if !destRoot.contains(toPath) {
+		return &protocol.AsyncResponseError{Index: ac.Index, Message: "rename failed: destination escapes storage root"}
+	}
 
 	os.MkdirAll(toDirPath, 0755)
 
@@ -781,6 +801,9 @@ func (s *Slave) handleRelocate(ac *protocol.AsyncCommand) interface{} {
 
 	toDirPath := destRoot.fullPath(toDir)
 	toPath := filepath.Join(toDirPath, toName)
+	if !destRoot.contains(toPath) {
+		return &protocol.AsyncResponseError{Index: ac.Index, Message: "relocate failed: destination escapes storage root"}
+	}
 	if err := os.MkdirAll(toDirPath, 0755); err != nil {
 		return &protocol.AsyncResponseError{Index: ac.Index, Message: fmt.Sprintf("relocate mkdir failed: %v", err)}
 	}


### PR DESCRIPTION
RNTO privilege escalation (arbitrary file write)
User path was not sanitized and could allow a user to rename a file to outside of the storage root

SITE CHMOD broken jail, running on the wrong host with no ACL
It looks like HandleSiteChmod always runs on the master's local disk, parse the path and validate against ACL before allowing