### PR TITLE
Remove InsecureSkipVerify where it doesn't make sense to skip. Implement mTLS between master and slave

### DIFF
--- a/cmd/weaveftpd/main.go
+++ b/cmd/weaveftpd/main.go
@@ -18,7 +18,6 @@ import (
 	"syscall"
 	"time"
 
-	"gopkg.in/yaml.v3"
 	"weaveftpd/internal/acl"
 	"weaveftpd/internal/core"
 	"weaveftpd/internal/dupe"
@@ -38,6 +37,8 @@ import (
 	"weaveftpd/plugins/spacekeeper"
 	"weaveftpd/plugins/speedtest"
 	"weaveftpd/plugins/tvmaze"
+
+	"gopkg.in/yaml.v3"
 )
 
 func main() {
@@ -133,6 +134,25 @@ func main() {
 		}
 		if err := sm.ConfigureAuthDenylistFile(stringFromCfg(cfg.Master, "slave_denylist_file", "etc/slave_denylist.txt")); err != nil {
 			log.Fatalf("Invalid master.slave_denylist_file: %v", err)
+		}
+		if err := sm.ConfigureSlaveMTLS(stringFromCfg(cfg.Master, "slave_ca_cert", "")); err != nil {
+			log.Fatalf("Invalid master.slave_ca_cert: %v", err)
+		}
+		if err := sm.ConfigureSlaveMasksFile(stringFromCfg(cfg.Master, "slave_masks_file", "etc/slave_masks.txt")); err != nil {
+			log.Fatalf("Invalid master.slave_masks_file: %v", err)
+		}
+		// One-time seed: apply any masks: entries from the slaves: config list
+		// for slave names that have no masks persisted yet. Once seeded,
+		// SITE SLAVE ADDMASK/DELMASK against slave_masks_file is authoritative.
+		for _, slaveCfg := range cfg.Slaves {
+			if len(slaveCfg.Masks) == 0 || len(sm.ListSlaveMasks(slaveCfg.Name)) > 0 {
+				continue
+			}
+			for _, mask := range slaveCfg.Masks {
+				if err := sm.AddSlaveMask(slaveCfg.Name, mask); err != nil {
+					log.Printf("[MASTER] failed to seed mask %q for slave %q: %v", mask, slaveCfg.Name, err)
+				}
+			}
 		}
 		sm.ConfigureAuthGuard(
 			intFromCfg(cfg.Master, "slave_auth_fail_limit", 2),
@@ -258,6 +278,12 @@ func main() {
 			}
 			if err := sm.ConfigureAuthDenylistFile(stringFromCfg(c.Master, "slave_denylist_file", "etc/slave_denylist.txt")); err != nil {
 				log.Printf("[REHASH] invalid master.slave_denylist_file: %v", err)
+			}
+			if err := sm.ConfigureSlaveMTLS(stringFromCfg(c.Master, "slave_ca_cert", "")); err != nil {
+				log.Printf("[REHASH] invalid master.slave_ca_cert: %v", err)
+			}
+			if err := sm.ConfigureSlaveMasksFile(stringFromCfg(c.Master, "slave_masks_file", "etc/slave_masks.txt")); err != nil {
+				log.Printf("[REHASH] invalid master.slave_masks_file: %v", err)
 			}
 			sm.ConfigureAuthGuard(
 				intFromCfg(c.Master, "slave_auth_fail_limit", 2),
@@ -566,6 +592,9 @@ func startSlave(cfg *core.Config) {
 	pasvMin := intFromCfg(slaveCfg, "pasv_port_min", 0)
 	pasvMax := intFromCfg(slaveCfg, "pasv_port_max", 0)
 	bindIP, _ := slaveCfg["bind_ip"].(string)
+	masterCACert, _ := slaveCfg["master_ca_cert"].(string)
+	clientCert, _ := slaveCfg["client_cert"].(string)
+	clientKey, _ := slaveCfg["client_key"].(string)
 	timeout := intFromCfg(slaveCfg, "timeout", 60)
 	transferBufferSize := intFromCfg(slaveCfg, "transfer_buffer_size", 0)
 	warnDeprecatedConfigKeys("slave", slaveCfg, map[string]string{
@@ -590,6 +619,9 @@ func startSlave(cfg *core.Config) {
 		TLSEnabled:         cfg.TLSEnabled,
 		TLSCert:            cfg.TLSCert,
 		TLSKey:             cfg.TLSKey,
+		MasterCACert:       masterCACert,
+		ClientCert:         clientCert,
+		ClientKey:          clientKey,
 		BindIP:             bindIP,
 		Timeout:            timeout,
 		TransferBufferSize: transferBufferSize,

--- a/etc/config-example.yml
+++ b/etc/config-example.yml
@@ -62,6 +62,15 @@ master:
   slave_denylist_file: "etc/slave_denylist.txt" # Persistent exact IP / CIDR denylist for the slave control port.
                                 # Managed manually or via SITE SLAVEBAN / SLAVEUNBAN / SLAVEBANS.
                                 # SITE SLAVECLEARBAN clears only active temp bans.
+  slave_ca_cert: ""             # Path to a CA cert (e.g. ./etc/certs/ca.crt) used to verify slave
+                                # client certificates - enables mTLS on the master-slave link and
+                                # requires every slave to present a cert whose CN matches its
+                                # registered slave name. Requires tls_enabled: true below.
+                                # Leave empty to fall back to the mandatory IP mask allowlist
+                                # (see slave_masks_file / SITE SLAVE <name> ADDMASK).
+  slave_masks_file: "etc/slave_masks.txt" # Per-slave IP/CIDR/wildcard allowlist, only enforced when
+                                # slave_ca_cert is empty. A slave name with zero registered masks
+                                # is refused. Managed via SITE SLAVE <name> ADDMASK/DELMASK/MASKS.
   heartbeat_timeout: 60         # Seconds before the master marks a silent slave offline.
                                 # The master will try a ping at about half this interval.
   slave_auth_fail_limit: 2      # Built-in guard for bad slave-port handshakes.
@@ -93,6 +102,12 @@ slave:
   name:          ""             # Unique slave identifier — MUST match an entry in `slaves:` below
   master_host:   ""             # IP or hostname of the master
   master_port:   1099           # Must match master's control_port
+  master_ca_cert: ""            # Path to the CA cert (e.g. ./etc/certs/ca.crt) used to verify the
+                                # master's presented server certificate. Leave empty only if you
+                                # accept an unverified master-slave link (InsecureSkipVerify).
+  client_cert:   ""             # This slave's own mTLS client certificate. Its CN MUST equal
+                                # `name` above - the master checks this. e.g. ./etc/certs/slave-SLAVE1.crt
+  client_key:    ""             # Private key for client_cert. e.g. ./etc/certs/slave-SLAVE1.key
   roots:         []             # REQUIRED in slave mode. Normal roots mounted at "/".
                                 # Example:
                                 #   - "/weaveftpd/site"
@@ -190,6 +205,10 @@ slave:
 #     sections: ["TV-1080P", "TV-720P"]
 #     paths: ["/TV-*/*"]
 #     weight: 2
+#     # Only used when master.slave_ca_cert is empty (no mTLS). Seeds
+#     # master.slave_masks_file the first time this slave name has no masks
+#     # registered yet; SITE SLAVE ADDMASK/DELMASK is authoritative after that.
+#     masks: ["203.0.113.10/32"]
 #   - name: "SLAVE2"
 #     sections: ["MP3", "FLAC"]
 #     weight: 1
@@ -301,9 +320,13 @@ msg_path:       "etc/msgs"      # Directory with welcome/rules/goodbye message t
 
 
 # =============================================================================
-#  TLS — used on both master and slaves (same cert pair on all boxes).
-#  tls_enabled makes TLS available. The require_* flags below actually force
-#  secure logins and encrypted data transfers for normal FTP users.
+#  TLS — the tls_cert/tls_key pair below is used for the FTP control+data
+#  channels (client-facing) and, when master.slave_ca_cert is unset, the
+#  plain server side of the master-slave link too. tls_enabled makes TLS
+#  available; the require_* flags force secure logins/transfers for FTP
+#  clients. For real mTLS on the master-slave link (recommended - see
+#  master.slave_ca_cert and slave.master_ca_cert/client_cert/client_key
+#  above), generate a dedicated CA + per-slave certs with `./setup.sh certs`.
 # =============================================================================
 tls_enabled: true
 tls_cert:    ./etc/certs/server.crt

--- a/etc/config-slave-example.yml
+++ b/etc/config-slave-example.yml
@@ -35,6 +35,18 @@ slave:
   master_host: "127.0.0.1"
   master_port: 1099
 
+  # Master-slave mTLS (recommended). master_ca_cert verifies the master's
+  # presented server cert (real verification instead of InsecureSkipVerify);
+  # client_cert/client_key is this slave's own identity - its CN MUST equal
+  # `name` above, since the master checks the two match. Generate all of
+  # these with `./setup.sh certs` on the master, then copy them here.
+  # Leave all three empty only if you accept an unverified link and have
+  # registered an IP mask for this slave name on the master instead
+  # (SITE SLAVE <name> ADDMASK <ip/cidr>).
+  master_ca_cert: "./etc/certs/ca.crt"
+  client_cert: "./etc/certs/slave-LOCAL.crt"
+  client_key: "./etc/certs/slave-LOCAL.key"
+
   # Normal site root(s), exposed at virtual "/".
   roots:
     - "./site"

--- a/internal/core/config.go
+++ b/internal/core/config.go
@@ -8,11 +8,12 @@ import (
 	"strings"
 	"sync"
 
-	"gopkg.in/yaml.v3"
 	"weaveftpd/internal/timeutil"
 	"weaveftpd/internal/user"
 	"weaveftpd/internal/versionfile"
 	"weaveftpd/internal/zipscript"
+
+	"gopkg.in/yaml.v3"
 )
 
 type Config struct {
@@ -183,6 +184,7 @@ type SlavePolicyConfig struct {
 	Weight   int                `yaml:"weight"`   // default 1, higher = more uploads routed here
 	ReadOnly bool               `yaml:"readonly"` // true = scan/download only; never route uploads here
 	Remerge  SlaveRemergeConfig `yaml:"remerge"`  // master-side background remerge policy for this slave
+	Masks    []string           `yaml:"masks"`    // Masks apply when mTLS is not used between master and slave
 }
 
 type SlaveRemergeConfig struct {

--- a/internal/core/master_bridge.go
+++ b/internal/core/master_bridge.go
@@ -179,6 +179,13 @@ type MasterBridge interface {
 	ClearSlaveAuthTempBan(entry string) (bool, error)
 	ListSlaveAuthTempBans() []SlaveAuthBanInfo
 
+	// Per-slave IP mask allowlist: the fallback authentication mechanism for
+	// the master-slave link when mTLS isn't configured (SITE SLAVE <name> ADDMASK/DELMASK/MASKS).
+	AddSlaveMask(name, mask string) error
+	RemoveSlaveMask(name, mask string) (bool, error)
+	ListSlaveMasks(name string) []string
+	ListAllSlaveMasks() map[string][]string
+
 	// GetLiveTransferStats asks connected slaves for current live transfer counters.
 	GetLiveTransferStats() []LiveTransferStat
 

--- a/internal/core/site_dispatcher.go
+++ b/internal/core/site_dispatcher.go
@@ -149,6 +149,8 @@ func (s *Session) DispatchSiteCommand(args []string) bool {
 		return s.HandleSiteSlaveUnban(remainingArgs)
 	case "SLAVECLEARBAN":
 		return s.HandleSiteSlaveClearBan(remainingArgs)
+	case "SLAVE":
+		return s.HandleSiteSlaveMask(remainingArgs)
 
 	// Miscellaneous (site_misc.go / site_race.go)
 	case "RACE":
@@ -238,6 +240,7 @@ func requiredSiteCommandFlags(command string) string {
 		"SLAVEBAN",
 		"SLAVEUNBAN",
 		"SLAVECLEARBAN",
+		"SLAVE",
 		"ADDAFFIL",
 		"DELAFFIL":
 		return "1"

--- a/internal/core/site_slaveauth.go
+++ b/internal/core/site_slaveauth.go
@@ -2,6 +2,7 @@ package core
 
 import (
 	"fmt"
+	"sort"
 	"strings"
 	"time"
 )
@@ -133,4 +134,97 @@ func (s *Session) HandleSiteSlaveClearBan(args []string) bool {
 	}
 	fmt.Fprintf(s.Conn, "200 Cleared active slave temp ban.\r\n")
 	return false
+}
+
+// HandleSiteSlaveMask implements the mandatory-when-no-mTLS fallback
+// authentication for the master-slave link: an IP/CIDR/wildcard allowlist
+// per slave name, in the style of drftpd's "site slave <name> addmask <mask>".
+//
+//	SITE SLAVE <name> ADDMASK <mask>
+//	SITE SLAVE <name> DELMASK <mask>
+//	SITE SLAVE <name> MASKS
+//	SITE SLAVE MASKS               (lists every slave's masks)
+func (s *Session) HandleSiteSlaveMask(args []string) bool {
+	if s.Config.Mode != "master" || s.MasterManager == nil {
+		fmt.Fprintf(s.Conn, "550 SITE SLAVE is only available in master mode.\r\n")
+		return false
+	}
+	bridge, ok := s.MasterManager.(MasterBridge)
+	if !ok {
+		fmt.Fprintf(s.Conn, "550 Master not initialized.\r\n")
+		return false
+	}
+
+	if len(args) == 1 && strings.EqualFold(args[0], "MASKS") {
+		all := bridge.ListAllSlaveMasks()
+		if len(all) == 0 {
+			fmt.Fprintf(s.Conn, "200 No slave masks registered.\r\n")
+			return false
+		}
+		names := make([]string, 0, len(all))
+		for name := range all {
+			names = append(names, name)
+		}
+		sort.Strings(names)
+		fmt.Fprintf(s.Conn, "200- Slave IP masks:\r\n")
+		for _, name := range names {
+			masks := all[name]
+			if len(masks) == 0 {
+				fmt.Fprintf(s.Conn, "200-   %s: (none)\r\n", name)
+				continue
+			}
+			fmt.Fprintf(s.Conn, "200-   %s: %s\r\n", name, strings.Join(masks, ", "))
+		}
+		fmt.Fprintf(s.Conn, "200 End of SLAVE MASKS\r\n")
+		return false
+	}
+
+	if len(args) < 2 {
+		fmt.Fprintf(s.Conn, "501 Usage: SITE SLAVE <name> ADDMASK|DELMASK <mask>, or SITE SLAVE <name> MASKS\r\n")
+		return false
+	}
+
+	name := args[0]
+	sub := strings.ToUpper(strings.TrimSpace(args[1]))
+
+	switch sub {
+	case "MASKS":
+		masks := bridge.ListSlaveMasks(name)
+		if len(masks) == 0 {
+			fmt.Fprintf(s.Conn, "200 No masks registered for slave %s.\r\n", name)
+			return false
+		}
+		fmt.Fprintf(s.Conn, "200 Masks for slave %s: %s\r\n", name, strings.Join(masks, ", "))
+		return false
+	case "ADDMASK":
+		if len(args) != 3 {
+			fmt.Fprintf(s.Conn, "501 Usage: SITE SLAVE <name> ADDMASK <ip|cidr|wildcard>\r\n")
+			return false
+		}
+		if err := bridge.AddSlaveMask(name, args[2]); err != nil {
+			fmt.Fprintf(s.Conn, "550 ADDMASK failed: %v\r\n", err)
+			return false
+		}
+		fmt.Fprintf(s.Conn, "200 Added mask %s for slave %s.\r\n", args[2], name)
+		return false
+	case "DELMASK":
+		if len(args) != 3 {
+			fmt.Fprintf(s.Conn, "501 Usage: SITE SLAVE <name> DELMASK <ip|cidr|wildcard>\r\n")
+			return false
+		}
+		removed, err := bridge.RemoveSlaveMask(name, args[2])
+		if err != nil {
+			fmt.Fprintf(s.Conn, "550 DELMASK failed: %v\r\n", err)
+			return false
+		}
+		if !removed {
+			fmt.Fprintf(s.Conn, "550 Mask %s not found for slave %s.\r\n", args[2], name)
+			return false
+		}
+		fmt.Fprintf(s.Conn, "200 Removed mask %s for slave %s.\r\n", args[2], name)
+		return false
+	default:
+		fmt.Fprintf(s.Conn, "501 Usage: SITE SLAVE <name> ADDMASK|DELMASK <mask>, or SITE SLAVE <name> MASKS\r\n")
+		return false
+	}
 }

--- a/internal/master/bridge.go
+++ b/internal/master/bridge.go
@@ -346,6 +346,34 @@ func (b *Bridge) ListSlaveAuthTempBans() []core.SlaveAuthBanInfo {
 	return out
 }
 
+func (b *Bridge) AddSlaveMask(name, mask string) error {
+	if b == nil || b.sm == nil {
+		return fmt.Errorf("master not initialized")
+	}
+	return b.sm.AddSlaveMask(name, mask)
+}
+
+func (b *Bridge) RemoveSlaveMask(name, mask string) (bool, error) {
+	if b == nil || b.sm == nil {
+		return false, fmt.Errorf("master not initialized")
+	}
+	return b.sm.RemoveSlaveMask(name, mask)
+}
+
+func (b *Bridge) ListSlaveMasks(name string) []string {
+	if b == nil || b.sm == nil {
+		return nil
+	}
+	return b.sm.ListSlaveMasks(name)
+}
+
+func (b *Bridge) ListAllSlaveMasks() map[string][]string {
+	if b == nil || b.sm == nil {
+		return nil
+	}
+	return b.sm.ListAllSlaveMasks()
+}
+
 func (b *Bridge) RunOnSlaveCommand(dirPath, command string, args []string, env map[string]string, timeoutSeconds int, preferredSlave string) (string, error) {
 	slave := b.resolveSlaveForDir(dirPath, preferredSlave)
 	if slave == nil {

--- a/internal/master/slave_manager.go
+++ b/internal/master/slave_manager.go
@@ -2,6 +2,7 @@ package master
 
 import (
 	"crypto/tls"
+	"crypto/x509"
 	"errors"
 	"fmt"
 	"io"
@@ -18,6 +19,7 @@ import (
 
 	"weaveftpd/internal/core"
 	"weaveftpd/internal/protocol"
+	"weaveftpd/internal/tlsutil"
 	"weaveftpd/internal/zipscript"
 )
 
@@ -86,6 +88,15 @@ type SlaveManager struct {
 	authAllowNets    []*net.IPNet
 	authDenyFile     string
 	authDenyEntries  []authNetworkEntry
+
+	// mTLS for the master-slave link. When slaveCACert is set, the listener
+	// requires and verifies a client certificate whose CN must match the
+	// claimed slave name (see handleSlaveConnection). When unset, masks
+	// below are the fallback (and mandatory) authentication mechanism.
+	slaveCACert string
+	slaveCAPool *x509.CertPool
+
+	masks slaveMasks
 
 	slaves   map[string]*RemoteSlave
 	slavesMu sync.RWMutex
@@ -208,6 +219,7 @@ func NewSlaveManager(host string, port int, tlsEnabled bool, tlsCert, tlsKey str
 		remergeCRCSem:         make(chan struct{}, defaultRemergeChecksumThreads),
 		backgroundRemergeWake: make(chan struct{}, 1),
 	}
+	sm.masks.byName = make(map[string][]string)
 	sm.remergeCRCSlots.Store(defaultRemergeChecksumThreads)
 	sm.remergeMode.Store("off")
 	sm.manualRemergeMode.Store("instant")
@@ -316,6 +328,45 @@ func (sm *SlaveManager) ConfigureAuthDenylistFile(filePath string) error {
 		return nil
 	}
 	return sm.loadAuthDenylistLocked()
+}
+
+// ConfigureSlaveMTLS sets the CA certificate used to verify slave client
+// certificates on the control-port TLS listener. An empty caCertPath
+// disables mTLS enforcement (masks become the mandatory fallback in
+// handleSlaveConnection).
+func (sm *SlaveManager) ConfigureSlaveMTLS(caCertPath string) error {
+	caCertPath = strings.TrimSpace(caCertPath)
+	if caCertPath == "" {
+		sm.slaveCACert = ""
+		sm.slaveCAPool = nil
+		return nil
+	}
+	pool, err := tlsutil.LoadCACertPool(caCertPath)
+	if err != nil {
+		return err
+	}
+	sm.slaveCACert = caCertPath
+	sm.slaveCAPool = pool
+	return nil
+}
+
+// mTLSActive reports whether slave client certificates are required and
+// verified on this listener.
+func (sm *SlaveManager) mTLSActive() bool {
+	return sm.slaveCACert != ""
+}
+
+// buildListenerTLSConfig builds the slave-control listener's TLS config,
+// requiring and verifying a slave client certificate when mTLS is active.
+// Extracted from Start() so tests can exercise it against a real
+// tls.Listen/tls.Dial pair without needing cert files on disk.
+func (sm *SlaveManager) buildListenerTLSConfig(cert tls.Certificate) *tls.Config {
+	cfg := &tls.Config{Certificates: []tls.Certificate{cert}}
+	if sm.mTLSActive() {
+		cfg.ClientCAs = sm.slaveCAPool
+		cfg.ClientAuth = tls.RequireAndVerifyClientCert
+	}
+	return cfg
 }
 
 func (sm *SlaveManager) publishDiskStatus(rs *RemoteSlave) {
@@ -712,8 +763,12 @@ func (sm *SlaveManager) Start() error {
 		if err != nil {
 			return fmt.Errorf("failed to load TLS cert: %w", err)
 		}
-		tlsCfg := &tls.Config{Certificates: []tls.Certificate{cert}}
-		listener, err = tls.Listen("tcp", addr, tlsCfg)
+		if sm.mTLSActive() {
+			log.Printf("[SlaveManager] mTLS enforced for slave connections (CA: %s)", sm.slaveCACert)
+		} else {
+			log.Printf("[SlaveManager] master.slave_ca_cert not set - falling back to per-slave IP mask allowlist")
+		}
+		listener, err = tls.Listen("tcp", addr, sm.buildListenerTLSConfig(cert))
 		if err != nil {
 			return fmt.Errorf("failed to listen TLS: %w", err)
 		}
@@ -792,6 +847,37 @@ func (sm *SlaveManager) handleSlaveConnection(conn net.Conn) {
 		log.Printf("[SlaveManager] Invalid slave name from %s", conn.RemoteAddr())
 		sm.recordAuthFailure(ip, remoteAddr, "invalid slave name")
 		stream.WriteObject(&protocol.AsyncCommand{Index: "error", Name: "error", Args: []string{"invalid slave name"}})
+		conn.Close()
+		return
+	}
+
+	// Tie the claimed slave name to a cryptographic or network identity: an
+	// unauthenticated name string is not sufficient on its own.
+	// If mTLS is configured, the presented client certificate's CN must match slaveName.
+	// Otherwise, the connecting IP must match a mask explicitly registered for slaveName.
+	// A slave with zero registered masks is refused, not silently trusted.
+	if sm.mTLSActive() {
+		tlsConn, ok := conn.(*tls.Conn)
+		if !ok {
+			log.Printf("[SlaveManager] Slave '%s' from %s did not use TLS while mTLS is required", slaveName, conn.RemoteAddr())
+			sm.recordAuthFailure(ip, remoteAddr, "mTLS required but connection is not TLS")
+			stream.WriteObject(&protocol.AsyncCommand{Index: "error", Name: "error", Args: []string{"mTLS required"}})
+			conn.Close()
+			return
+		}
+		if err := tlsutil.VerifyPeerCommonName(tlsConn.ConnectionState(), slaveName); err != nil {
+			log.Printf("[SlaveManager] Slave '%s' from %s failed certificate identity check: %v", slaveName, conn.RemoteAddr(), err)
+			sm.recordAuthFailure(ip, remoteAddr, "client certificate does not match slave name")
+			sm.publishSecurityEvent(ip, remoteAddr, "deny", fmt.Sprintf("client certificate CN mismatch for slave %q", slaveName), 0, time.Time{})
+			stream.WriteObject(&protocol.AsyncCommand{Index: "error", Name: "error", Args: []string{"certificate identity mismatch"}})
+			conn.Close()
+			return
+		}
+	} else if !sm.slaveMaskAllows(slaveName, ip) {
+		log.Printf("[SlaveManager] Slave '%s' from %s has no matching IP mask registered, rejecting", slaveName, conn.RemoteAddr())
+		sm.recordAuthFailure(ip, remoteAddr, "no matching IP mask for slave")
+		sm.publishSecurityEvent(ip, remoteAddr, "deny", fmt.Sprintf("no IP mask registered for slave %q", slaveName), 0, time.Time{})
+		stream.WriteObject(&protocol.AsyncCommand{Index: "error", Name: "error", Args: []string{"no matching IP mask registered for this slave"}})
 		conn.Close()
 		return
 	}

--- a/internal/master/slave_masks.go
+++ b/internal/master/slave_masks.go
@@ -1,0 +1,262 @@
+package master
+
+import (
+	"fmt"
+	"net"
+	"os"
+	"path/filepath"
+	"sort"
+	"strconv"
+	"strings"
+	"sync"
+)
+
+// Per-slave IP mask allowlist, used as the fallback authentication mechanism
+// when the master-slave link isn't using mTLS (SlaveManager.slaveCACert
+// unset). Unlike the global authDenyEntries/authAllowNets list, this is
+// keyed by slave name (drftpd-style "site slave <name> addmask <mask>"), and
+// intentionally lives here rather than on RemoteSlave: masks must be
+// checked before a RemoteSlave exists (pre-auth) and must work for slave
+// names that have never connected.
+type slaveMasks struct {
+	mu     sync.RWMutex
+	file   string
+	byName map[string][]string
+}
+
+// ConfigureSlaveMasksFile sets the path used to persist per-slave IP masks
+// and loads any existing entries from it.
+func (sm *SlaveManager) ConfigureSlaveMasksFile(path string) error {
+	sm.masks.mu.Lock()
+	defer sm.masks.mu.Unlock()
+	sm.masks.file = strings.TrimSpace(path)
+	return sm.loadSlaveMasksLocked()
+}
+
+func (sm *SlaveManager) loadSlaveMasksLocked() error {
+	sm.masks.byName = make(map[string][]string)
+	if sm.masks.file == "" {
+		return nil
+	}
+	data, err := os.ReadFile(sm.masks.file)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return err
+	}
+	for line := range strings.SplitSeq(string(data), "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		fields := strings.Fields(line)
+		if len(fields) != 2 {
+			return fmt.Errorf("%s: invalid slave mask line %q (expected \"<name> <mask>\")", sm.masks.file, line)
+		}
+		name, mask := fields[0], fields[1]
+		if err := validateMaskSyntax(mask); err != nil {
+			return fmt.Errorf("%s: %w", sm.masks.file, err)
+		}
+		sm.masks.byName[name] = append(sm.masks.byName[name], mask)
+	}
+	return nil
+}
+
+func (sm *SlaveManager) saveSlaveMasksLocked() error {
+	if sm.masks.file == "" {
+		return nil
+	}
+	if err := os.MkdirAll(filepath.Dir(sm.masks.file), 0755); err != nil {
+		return err
+	}
+	names := make([]string, 0, len(sm.masks.byName))
+	for name := range sm.masks.byName {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+
+	lines := []string{"# Per-slave IP mask allowlist: \"<slave name> <ip|cidr|wildcard>\", one per line."}
+	for _, name := range names {
+		for _, mask := range sm.masks.byName[name] {
+			lines = append(lines, name+" "+mask)
+		}
+	}
+	content := strings.Join(lines, "\n") + "\n"
+	return os.WriteFile(sm.masks.file, []byte(content), 0644)
+}
+
+// AddSlaveMask registers an allowed IP/CIDR/wildcard mask for the given slave
+// name and persists it.
+func (sm *SlaveManager) AddSlaveMask(name, mask string) error {
+	name = strings.TrimSpace(name)
+	mask = strings.TrimSpace(mask)
+	if name == "" {
+		return fmt.Errorf("slave name required")
+	}
+	if err := validateMaskSyntax(mask); err != nil {
+		return err
+	}
+	sm.masks.mu.Lock()
+	defer sm.masks.mu.Unlock()
+	if sm.masks.byName == nil {
+		sm.masks.byName = make(map[string][]string)
+	}
+	for _, existing := range sm.masks.byName[name] {
+		if strings.EqualFold(existing, mask) {
+			return nil
+		}
+	}
+	sm.masks.byName[name] = append(sm.masks.byName[name], mask)
+	sort.Strings(sm.masks.byName[name])
+	return sm.saveSlaveMasksLocked()
+}
+
+// RemoveSlaveMask removes a previously registered mask for the given slave
+// name. Returns false if the mask wasn't present.
+func (sm *SlaveManager) RemoveSlaveMask(name, mask string) (bool, error) {
+	name = strings.TrimSpace(name)
+	mask = strings.TrimSpace(mask)
+	sm.masks.mu.Lock()
+	defer sm.masks.mu.Unlock()
+	existing := sm.masks.byName[name]
+	out := existing[:0]
+	removed := false
+	for _, m := range existing {
+		if strings.EqualFold(m, mask) {
+			removed = true
+			continue
+		}
+		out = append(out, m)
+	}
+	if !removed {
+		return false, nil
+	}
+	if len(out) == 0 {
+		delete(sm.masks.byName, name)
+	} else {
+		sm.masks.byName[name] = out
+	}
+	if err := sm.saveSlaveMasksLocked(); err != nil {
+		return false, err
+	}
+	return true, nil
+}
+
+// ListSlaveMasks returns the masks registered for a single slave name.
+func (sm *SlaveManager) ListSlaveMasks(name string) []string {
+	sm.masks.mu.RLock()
+	defer sm.masks.mu.RUnlock()
+	out := make([]string, len(sm.masks.byName[name]))
+	copy(out, sm.masks.byName[name])
+	return out
+}
+
+// ListAllSlaveMasks returns every slave name's registered masks.
+func (sm *SlaveManager) ListAllSlaveMasks() map[string][]string {
+	sm.masks.mu.RLock()
+	defer sm.masks.mu.RUnlock()
+	out := make(map[string][]string, len(sm.masks.byName))
+	for name, masks := range sm.masks.byName {
+		cp := make([]string, len(masks))
+		copy(cp, masks)
+		out[name] = cp
+	}
+	return out
+}
+
+// slaveMaskAllows reports whether ip is permitted to register as the given
+// slave name under the currently configured masks. A name with zero
+// registered masks is denied (fail closed) - this is the whole point of the
+// fallback when mTLS isn't configured.
+func (sm *SlaveManager) slaveMaskAllows(name, ip string) bool {
+	sm.masks.mu.RLock()
+	masks := sm.masks.byName[name]
+	sm.masks.mu.RUnlock()
+	if len(masks) == 0 {
+		return false
+	}
+	for _, mask := range masks {
+		if maskMatchesIP(mask, ip) {
+			return true
+		}
+	}
+	return false
+}
+
+func validateMaskSyntax(raw string) error {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return fmt.Errorf("empty mask")
+	}
+	if strings.Contains(raw, "/") {
+		if _, _, err := net.ParseCIDR(raw); err != nil {
+			return fmt.Errorf("invalid CIDR mask %q: %w", raw, err)
+		}
+		return nil
+	}
+	if strings.Contains(raw, "*") {
+		parts := strings.Split(raw, ".")
+		if len(parts) != 4 {
+			return fmt.Errorf("invalid wildcard mask %q: expected 4 dot-separated octets", raw)
+		}
+		for _, p := range parts {
+			if p == "*" {
+				continue
+			}
+			n, err := strconv.Atoi(p)
+			if err != nil || n < 0 || n > 255 {
+				return fmt.Errorf("invalid wildcard mask %q: bad octet %q", raw, p)
+			}
+		}
+		return nil
+	}
+	if net.ParseIP(raw) == nil {
+		return fmt.Errorf("invalid mask %q: not an IP, CIDR, or wildcard pattern", raw)
+	}
+	return nil
+}
+
+// maskMatchesIP checks ip (bare IP string) against a single mask entry,
+// which may be a CIDR ("1.2.3.4/32"), a drftpd-style IPv4 wildcard
+// ("1.2.3.*"), or a bare IP (exact match).
+func maskMatchesIP(mask, ip string) bool {
+	mask = strings.TrimSpace(mask)
+	parsedIP := net.ParseIP(strings.TrimSpace(ip))
+	if mask == "" || parsedIP == nil {
+		return false
+	}
+	if strings.Contains(mask, "/") {
+		_, network, err := net.ParseCIDR(mask)
+		if err != nil {
+			return false
+		}
+		return network.Contains(parsedIP)
+	}
+	if strings.Contains(mask, "*") {
+		return wildcardMatches(mask, parsedIP)
+	}
+	maskIP := net.ParseIP(mask)
+	return maskIP != nil && maskIP.Equal(parsedIP)
+}
+
+func wildcardMatches(mask string, ip net.IP) bool {
+	ip4 := ip.To4()
+	if ip4 == nil {
+		return false
+	}
+	maskParts := strings.Split(mask, ".")
+	if len(maskParts) != 4 {
+		return false
+	}
+	ipParts := strings.Split(ip4.String(), ".")
+	for i, part := range maskParts {
+		if part == "*" {
+			continue
+		}
+		if part != ipParts[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/master/slave_masks_test.go
+++ b/internal/master/slave_masks_test.go
@@ -1,0 +1,120 @@
+package master
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestMaskMatchesIP(t *testing.T) {
+	cases := []struct {
+		mask string
+		ip   string
+		want bool
+	}{
+		{"1.2.3.4/32", "1.2.3.4", true},
+		{"1.2.3.4/32", "1.2.3.5", false},
+		{"1.2.3.0/24", "1.2.3.200", true},
+		{"1.2.3.0/24", "1.2.4.1", false},
+		{"1.2.3.*", "1.2.3.55", true},
+		{"1.2.3.*", "1.2.4.55", false},
+		{"1.2.*.4", "1.2.99.4", true},
+		{"1.2.*.4", "1.2.99.5", false},
+		{"127.0.0.1", "127.0.0.1", true},
+		{"127.0.0.1", "127.0.0.2", false},
+		{"", "127.0.0.1", false},
+	}
+	for _, tc := range cases {
+		if got := maskMatchesIP(tc.mask, tc.ip); got != tc.want {
+			t.Errorf("maskMatchesIP(%q, %q) = %v, want %v", tc.mask, tc.ip, got, tc.want)
+		}
+	}
+}
+
+func TestValidateMaskSyntax(t *testing.T) {
+	valid := []string{"1.2.3.4/32", "1.2.3.0/24", "1.2.3.*", "1.2.3.4", "::1"}
+	for _, m := range valid {
+		if err := validateMaskSyntax(m); err != nil {
+			t.Errorf("expected %q to be valid, got error: %v", m, err)
+		}
+	}
+	invalid := []string{"", "not-an-ip", "1.2.3.999", "1.2.3", "1.2.3.4/abc"}
+	for _, m := range invalid {
+		if err := validateMaskSyntax(m); err == nil {
+			t.Errorf("expected %q to be invalid", m)
+		}
+	}
+}
+
+func TestSlaveManagerMasksAddRemoveList(t *testing.T) {
+	sm := NewSlaveManager("127.0.0.1", 1099, false, "", "", 60*time.Second)
+	dir := t.TempDir()
+	maskFile := filepath.Join(dir, "slave_masks.txt")
+	if err := sm.ConfigureSlaveMasksFile(maskFile); err != nil {
+		t.Fatalf("ConfigureSlaveMasksFile: %v", err)
+	}
+
+	if masks := sm.ListSlaveMasks("SLAVE1"); len(masks) != 0 {
+		t.Fatalf("expected no masks for unregistered slave, got %v", masks)
+	}
+
+	if err := sm.AddSlaveMask("SLAVE1", "1.2.3.4/32"); err != nil {
+		t.Fatalf("AddSlaveMask: %v", err)
+	}
+	if err := sm.AddSlaveMask("SLAVE1", "1.2.3.4/32"); err != nil { // duplicate, no-op
+		t.Fatalf("AddSlaveMask duplicate: %v", err)
+	}
+	if err := sm.AddSlaveMask("SLAVE1", "bad mask"); err == nil {
+		t.Fatal("expected error for invalid mask syntax")
+	}
+
+	masks := sm.ListSlaveMasks("SLAVE1")
+	if len(masks) != 1 || masks[0] != "1.2.3.4/32" {
+		t.Fatalf("expected [\"1.2.3.4/32\"], got %v", masks)
+	}
+
+	if !sm.slaveMaskAllows("SLAVE1", "1.2.3.4") {
+		t.Fatal("expected SLAVE1 to be allowed from 1.2.3.4")
+	}
+	if sm.slaveMaskAllows("SLAVE1", "9.9.9.9") {
+		t.Fatal("expected SLAVE1 to be denied from 9.9.9.9")
+	}
+	// Fail closed: a slave name with zero masks is always denied.
+	if sm.slaveMaskAllows("NEVERREGISTERED", "127.0.0.1") {
+		t.Fatal("expected fail-closed denial for a slave with no registered masks")
+	}
+
+	removed, err := sm.RemoveSlaveMask("SLAVE1", "1.2.3.4/32")
+	if err != nil || !removed {
+		t.Fatalf("RemoveSlaveMask: removed=%v err=%v", removed, err)
+	}
+	if len(sm.ListSlaveMasks("SLAVE1")) != 0 {
+		t.Fatal("expected no masks after removal")
+	}
+	removed, err = sm.RemoveSlaveMask("SLAVE1", "1.2.3.4/32")
+	if err != nil || removed {
+		t.Fatalf("expected second removal to report not-found, got removed=%v err=%v", removed, err)
+	}
+
+	// Persistence round-trip: a fresh SlaveManager loading the same file
+	// should see what was saved.
+	if err := sm.AddSlaveMask("SLAVE2", "10.0.0.0/8"); err != nil {
+		t.Fatalf("AddSlaveMask SLAVE2: %v", err)
+	}
+	if _, err := os.Stat(maskFile); err != nil {
+		t.Fatalf("expected mask file to exist: %v", err)
+	}
+
+	sm2 := NewSlaveManager("127.0.0.1", 1099, false, "", "", 60*time.Second)
+	if err := sm2.ConfigureSlaveMasksFile(maskFile); err != nil {
+		t.Fatalf("ConfigureSlaveMasksFile (reload): %v", err)
+	}
+	all := sm2.ListAllSlaveMasks()
+	if len(all["SLAVE2"]) != 1 || all["SLAVE2"][0] != "10.0.0.0/8" {
+		t.Fatalf("expected reloaded masks for SLAVE2, got %v", all)
+	}
+	if _, ok := all["SLAVE1"]; ok {
+		t.Fatalf("did not expect SLAVE1 entry after its only mask was removed, got %v", all)
+	}
+}

--- a/internal/master/slave_mtls_integration_test.go
+++ b/internal/master/slave_mtls_integration_test.go
@@ -1,0 +1,205 @@
+package master
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"math/big"
+	"net"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"weaveftpd/internal/tlsutil"
+)
+
+// This test exercises the actual security fix end-to-end: a real
+// tls.Listen/tls.Dial pair configured exactly the way SlaveManager.Start()
+// configures the slave-control listener (buildListenerTLSConfig), driving
+// real TLS handshakes rather than just unit-testing helper functions.
+
+type testCA struct {
+	cert *x509.Certificate
+	key  *ecdsa.PrivateKey
+}
+
+func newTestCA(t *testing.T) *testCA {
+	t.Helper()
+	key, err := ecdsa.GenerateKey(elliptic.P384(), rand.Reader)
+	if err != nil {
+		t.Fatalf("generate CA key: %v", err)
+	}
+	tmpl := &x509.Certificate{
+		SerialNumber:          big.NewInt(1),
+		Subject:               pkix.Name{CommonName: "Test Root CA"},
+		NotBefore:             time.Now().Add(-time.Hour),
+		NotAfter:              time.Now().Add(24 * time.Hour),
+		IsCA:                  true,
+		KeyUsage:              x509.KeyUsageCertSign | x509.KeyUsageCRLSign,
+		BasicConstraintsValid: true,
+	}
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, &key.PublicKey, key)
+	if err != nil {
+		t.Fatalf("create CA cert: %v", err)
+	}
+	cert, err := x509.ParseCertificate(der)
+	if err != nil {
+		t.Fatalf("parse CA cert: %v", err)
+	}
+	return &testCA{cert: cert, key: key}
+}
+
+func (ca *testCA) issueServerCert(t *testing.T, sans []net.IP) tls.Certificate {
+	t.Helper()
+	key, err := ecdsa.GenerateKey(elliptic.P384(), rand.Reader)
+	if err != nil {
+		t.Fatalf("generate server key: %v", err)
+	}
+	tmpl := &x509.Certificate{
+		SerialNumber: big.NewInt(2),
+		Subject:      pkix.Name{CommonName: "Test Master"},
+		NotBefore:    time.Now().Add(-time.Hour),
+		NotAfter:     time.Now().Add(24 * time.Hour),
+		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		IPAddresses:  sans,
+	}
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, ca.cert, &key.PublicKey, ca.key)
+	if err != nil {
+		t.Fatalf("create server cert: %v", err)
+	}
+	return tls.Certificate{Certificate: [][]byte{der}, PrivateKey: key}
+}
+
+func (ca *testCA) issueClientCert(t *testing.T, cn string) tls.Certificate {
+	t.Helper()
+	key, err := ecdsa.GenerateKey(elliptic.P384(), rand.Reader)
+	if err != nil {
+		t.Fatalf("generate client key: %v", err)
+	}
+	tmpl := &x509.Certificate{
+		SerialNumber: big.NewInt(time.Now().UnixNano() % 1_000_000),
+		Subject:      pkix.Name{CommonName: cn},
+		NotBefore:    time.Now().Add(-time.Hour),
+		NotAfter:     time.Now().Add(24 * time.Hour),
+		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth},
+	}
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, ca.cert, &key.PublicKey, ca.key)
+	if err != nil {
+		t.Fatalf("create client cert for CN=%s: %v", cn, err)
+	}
+	return tls.Certificate{Certificate: [][]byte{der}, PrivateKey: key}
+}
+
+func (ca *testCA) pool() *x509.CertPool {
+	pool := x509.NewCertPool()
+	pool.AddCert(ca.cert)
+	return pool
+}
+
+func TestSlaveManagerMTLSListenerRejectsWrongOrMissingClientCert(t *testing.T) {
+	ca := newTestCA(t)
+	serverCert := ca.issueServerCert(t, []net.IP{net.ParseIP("127.0.0.1")})
+	slave1Cert := ca.issueClientCert(t, "SLAVE1")
+	otherCert := ca.issueClientCert(t, "IMPOSTOR")
+
+	caCertPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: ca.cert.Raw})
+	caCertPath := filepath.Join(t.TempDir(), "ca.crt")
+	if err := os.WriteFile(caCertPath, caCertPEM, 0644); err != nil {
+		t.Fatalf("write ca.crt: %v", err)
+	}
+
+	sm := NewSlaveManager("127.0.0.1", 0, true, "", "", 60*time.Second)
+	if err := sm.ConfigureSlaveMTLS(caCertPath); err != nil {
+		t.Fatalf("ConfigureSlaveMTLS: %v", err)
+	}
+	if !sm.mTLSActive() {
+		t.Fatal("expected mTLS to be active once slave_ca_cert is configured")
+	}
+
+	ln, err := tls.Listen("tcp", "127.0.0.1:0", sm.buildListenerTLSConfig(serverCert))
+	if err != nil {
+		t.Fatalf("tls.Listen: %v", err)
+	}
+	defer ln.Close()
+
+	acceptOnce := func() (*tls.Conn, error) {
+		conn, err := ln.Accept()
+		if err != nil {
+			return nil, err
+		}
+		tlsConn := conn.(*tls.Conn)
+		return tlsConn, tlsConn.Handshake()
+	}
+
+	t.Run("correct CN is accepted and identity check passes", func(t *testing.T) {
+		errCh := make(chan error, 1)
+		go func() {
+			tlsConn, err := acceptOnce()
+			if err != nil {
+				errCh <- err
+				return
+			}
+			defer tlsConn.Close()
+			errCh <- tlsutil.VerifyPeerCommonName(tlsConn.ConnectionState(), "SLAVE1")
+		}()
+
+		clientCfg := &tls.Config{RootCAs: ca.pool(), Certificates: []tls.Certificate{slave1Cert}, ServerName: "127.0.0.1"}
+		conn, err := tls.Dial("tcp", ln.Addr().String(), clientCfg)
+		if err != nil {
+			t.Fatalf("client dial: %v", err)
+		}
+		defer conn.Close()
+
+		if err := <-errCh; err != nil {
+			t.Fatalf("expected accept + CN match, got: %v", err)
+		}
+	})
+
+	t.Run("wrong CN handshakes fine but fails the application-level identity check", func(t *testing.T) {
+		errCh := make(chan error, 1)
+		go func() {
+			tlsConn, err := acceptOnce()
+			if err != nil {
+				errCh <- err
+				return
+			}
+			defer tlsConn.Close()
+			errCh <- tlsutil.VerifyPeerCommonName(tlsConn.ConnectionState(), "SLAVE1")
+		}()
+
+		clientCfg := &tls.Config{RootCAs: ca.pool(), Certificates: []tls.Certificate{otherCert}, ServerName: "127.0.0.1"}
+		conn, err := tls.Dial("tcp", ln.Addr().String(), clientCfg)
+		if err != nil {
+			t.Fatalf("client dial: %v", err)
+		}
+		defer conn.Close()
+
+		if err := <-errCh; err == nil {
+			t.Fatal("expected CN mismatch to be rejected by the application-level identity check")
+		}
+	})
+
+	t.Run("missing client cert fails the TLS handshake itself", func(t *testing.T) {
+		errCh := make(chan error, 1)
+		go func() {
+			_, err := acceptOnce()
+			errCh <- err
+		}()
+
+		clientCfg := &tls.Config{RootCAs: ca.pool(), ServerName: "127.0.0.1"} // no client cert
+		conn, dialErr := tls.Dial("tcp", ln.Addr().String(), clientCfg)
+		if conn != nil {
+			defer conn.Close()
+		}
+
+		serverErr := <-errCh
+		if dialErr == nil && serverErr == nil {
+			t.Fatal("expected the handshake to fail without a client certificate when RequireAndVerifyClientCert is set")
+		}
+	})
+}

--- a/internal/slave/slave.go
+++ b/internal/slave/slave.go
@@ -24,6 +24,7 @@ import (
 
 	"weaveftpd/internal/metrics"
 	"weaveftpd/internal/protocol"
+	"weaveftpd/internal/tlsutil"
 )
 
 const (
@@ -50,6 +51,9 @@ type Slave struct {
 	tlsKey             string
 	tlsServerConfig    *tls.Config
 	tlsServerConfigErr error
+	masterCACert       string // CA used to verify the master's presented cert; empty = legacy InsecureSkipVerify
+	clientCert         string // this slave's own mTLS identity presented to the master
+	clientKey          string
 	bindIP             string
 	transferBufferSize int
 	freeSpaceMB        int
@@ -122,6 +126,9 @@ type SlaveConfig struct {
 	TLSEnabled         bool          `yaml:"tls_enabled"`
 	TLSCert            string        `yaml:"tls_cert"`
 	TLSKey             string        `yaml:"tls_key"`
+	MasterCACert       string        `yaml:"master_ca_cert"` // CA cert used to verify the master's server cert
+	ClientCert         string        `yaml:"client_cert"`    // this slave's mTLS client cert (CN must equal Name)
+	ClientKey          string        `yaml:"client_key"`
 	BindIP             string        `yaml:"bind_ip"`
 	Timeout            int           `yaml:"timeout"` // seconds, default 60
 	TransferBufferSize int           `yaml:"transfer_buffer_size"`
@@ -163,6 +170,9 @@ func NewSlave(cfg SlaveConfig) *Slave {
 		tlsKey:             cfg.TLSKey,
 		tlsServerConfig:    tlsServerConfig,
 		tlsServerConfigErr: tlsServerConfigErr,
+		masterCACert:       cfg.MasterCACert,
+		clientCert:         cfg.ClientCert,
+		clientKey:          cfg.ClientKey,
 		bindIP:             cfg.BindIP,
 		timeout:            timeout,
 		transferBufferSize: bufferSize,
@@ -177,6 +187,37 @@ func loadTLSServerConfig(certPath, keyPath string) (*tls.Config, error) {
 		return nil, err
 	}
 	return &tls.Config{Certificates: []tls.Certificate{cert}, DynamicRecordSizingDisabled: true}, nil
+}
+
+// buildMasterTLSConfig builds the TLS config used to dial the master's
+// control port. When masterCACert is configured, the master's presented
+// server certificate is verified against it (real verification, replacing
+// the historical InsecureSkipVerify bypass); when clientCert/clientKey are
+// also configured, this slave presents its own mTLS identity (CN must equal
+// its registered slave name for the master's handshake check to pass).
+func (s *Slave) buildMasterTLSConfig() (*tls.Config, error) {
+	tlsCfg := &tls.Config{ServerName: s.masterHost}
+
+	if s.masterCACert != "" {
+		pool, err := tlsutil.LoadCACertPool(s.masterCACert)
+		if err != nil {
+			return nil, fmt.Errorf("failed to load master_ca_cert: %w", err)
+		}
+		tlsCfg.RootCAs = pool
+	} else {
+		log.Printf("[Slave] WARNING: slave.master_ca_cert is not set - the master's certificate will not be verified (InsecureSkipVerify). Configure mTLS for a verified master-slave link.")
+		tlsCfg.InsecureSkipVerify = true
+	}
+
+	if s.clientCert != "" && s.clientKey != "" {
+		cert, err := tls.LoadX509KeyPair(s.clientCert, s.clientKey)
+		if err != nil {
+			return nil, fmt.Errorf("failed to load client_cert/client_key: %w", err)
+		}
+		tlsCfg.Certificates = []tls.Certificate{cert}
+	}
+
+	return tlsCfg, nil
 }
 
 func normalizeMountedRoots(configured []MountedRoot, legacy []string) []MountedRoot {
@@ -475,7 +516,10 @@ func (s *Slave) connectAndRun() error {
 	var err error
 
 	if s.tlsEnabled {
-		tlsCfg := &tls.Config{InsecureSkipVerify: true}
+		tlsCfg, cfgErr := s.buildMasterTLSConfig()
+		if cfgErr != nil {
+			return fmt.Errorf("failed to build master TLS config: %w", cfgErr)
+		}
 		conn, err = tls.DialWithDialer(&net.Dialer{Timeout: socketTimeout}, "tcp", addr, tlsCfg)
 	} else {
 		conn, err = net.DialTimeout("tcp", addr, socketTimeout)

--- a/internal/slave/slave_tls_test.go
+++ b/internal/slave/slave_tls_test.go
@@ -1,0 +1,109 @@
+package slave
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"math/big"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func writeSelfSignedPair(t *testing.T, dir, prefix string) (certPath, keyPath string) {
+	t.Helper()
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("generate key: %v", err)
+	}
+	tmpl := &x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		Subject:      pkix.Name{CommonName: prefix},
+		NotBefore:    time.Now().Add(-time.Hour),
+		NotAfter:     time.Now().Add(time.Hour),
+	}
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, &key.PublicKey, key)
+	if err != nil {
+		t.Fatalf("create cert: %v", err)
+	}
+	certPath = filepath.Join(dir, prefix+".crt")
+	keyPath = filepath.Join(dir, prefix+".key")
+	certPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der})
+	keyDER, err := x509.MarshalECPrivateKey(key)
+	if err != nil {
+		t.Fatalf("marshal key: %v", err)
+	}
+	keyPEM := pem.EncodeToMemory(&pem.Block{Type: "EC PRIVATE KEY", Bytes: keyDER})
+	if err := os.WriteFile(certPath, certPEM, 0644); err != nil {
+		t.Fatalf("write cert: %v", err)
+	}
+	if err := os.WriteFile(keyPath, keyPEM, 0644); err != nil {
+		t.Fatalf("write key: %v", err)
+	}
+	return certPath, keyPath
+}
+
+func TestBuildMasterTLSConfigWithoutCA(t *testing.T) {
+	s := &Slave{masterHost: "127.0.0.1"}
+	cfg, err := s.buildMasterTLSConfig()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !cfg.InsecureSkipVerify {
+		t.Fatal("expected InsecureSkipVerify=true when master_ca_cert is unset (legacy fallback)")
+	}
+	if cfg.RootCAs != nil {
+		t.Fatal("expected no RootCAs when master_ca_cert is unset")
+	}
+}
+
+func TestBuildMasterTLSConfigWithCA(t *testing.T) {
+	dir := t.TempDir()
+	caCertPath, _ := writeSelfSignedPair(t, dir, "ca")
+
+	s := &Slave{masterHost: "master.example.net", masterCACert: caCertPath}
+	cfg, err := s.buildMasterTLSConfig()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg.InsecureSkipVerify {
+		t.Fatal("expected verification enabled (InsecureSkipVerify=false) when master_ca_cert is set")
+	}
+	if cfg.RootCAs == nil {
+		t.Fatal("expected RootCAs to be populated")
+	}
+	if cfg.ServerName != "master.example.net" {
+		t.Fatalf("expected ServerName to default to masterHost, got %q", cfg.ServerName)
+	}
+}
+
+func TestBuildMasterTLSConfigWithClientCert(t *testing.T) {
+	dir := t.TempDir()
+	caCertPath, _ := writeSelfSignedPair(t, dir, "ca")
+	clientCertPath, clientKeyPath := writeSelfSignedPair(t, dir, "slave1")
+
+	s := &Slave{
+		masterHost:   "127.0.0.1",
+		masterCACert: caCertPath,
+		clientCert:   clientCertPath,
+		clientKey:    clientKeyPath,
+	}
+	cfg, err := s.buildMasterTLSConfig()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(cfg.Certificates) != 1 {
+		t.Fatalf("expected one client certificate to be presented, got %d", len(cfg.Certificates))
+	}
+}
+
+func TestBuildMasterTLSConfigBadCAPath(t *testing.T) {
+	s := &Slave{masterHost: "127.0.0.1", masterCACert: "/nonexistent/ca.crt"}
+	if _, err := s.buildMasterTLSConfig(); err == nil {
+		t.Fatal("expected error for missing master_ca_cert file")
+	}
+}

--- a/internal/tlsutil/tlsutil.go
+++ b/internal/tlsutil/tlsutil.go
@@ -1,0 +1,40 @@
+// Package tlsutil holds small TLS helpers shared by the master and slave
+// mTLS code paths (loading a CA trust pool, and checking a verified peer
+// certificate's identity against an expected name).
+package tlsutil
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+	"fmt"
+	"os"
+)
+
+// LoadCACertPool reads a PEM-encoded CA certificate (or bundle) from path
+// and returns an *x509.CertPool containing it.
+func LoadCACertPool(path string) (*x509.CertPool, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read CA cert %q: %w", path, err)
+	}
+	pool := x509.NewCertPool()
+	if !pool.AppendCertsFromPEM(data) {
+		return nil, fmt.Errorf("no valid certificates found in %q", path)
+	}
+	return pool, nil
+}
+
+// VerifyPeerCommonName checks that the already-verified peer certificate
+// chain (state.PeerCertificates, populated by crypto/tls once ClientAuth is
+// set to VerifyClientCertIfGiven/RequireAndVerifyClientCert) presents a leaf
+// certificate whose Subject.CommonName equals expected.
+func VerifyPeerCommonName(state tls.ConnectionState, expected string) error {
+	if len(state.PeerCertificates) == 0 {
+		return fmt.Errorf("no peer certificate presented")
+	}
+	cn := state.PeerCertificates[0].Subject.CommonName
+	if cn != expected {
+		return fmt.Errorf("peer certificate CN %q does not match expected identity %q", cn, expected)
+	}
+	return nil
+}

--- a/internal/tlsutil/tlsutil_test.go
+++ b/internal/tlsutil/tlsutil_test.go
@@ -1,0 +1,101 @@
+package tlsutil
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"math/big"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func generateSelfSignedPEM(t *testing.T, cn string) (certPEM []byte, cert *x509.Certificate) {
+	t.Helper()
+	priv, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("generate key: %v", err)
+	}
+	tmpl := &x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		Subject:      pkix.Name{CommonName: cn},
+		NotBefore:    time.Now().Add(-time.Hour),
+		NotAfter:     time.Now().Add(time.Hour),
+		IsCA:         true,
+		KeyUsage:     x509.KeyUsageCertSign,
+	}
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, &priv.PublicKey, priv)
+	if err != nil {
+		t.Fatalf("create cert: %v", err)
+	}
+	certPEM = pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der})
+	parsed, err := x509.ParseCertificate(der)
+	if err != nil {
+		t.Fatalf("parse cert: %v", err)
+	}
+	return certPEM, parsed
+}
+
+func TestLoadCACertPool(t *testing.T) {
+	certPEM, _ := generateSelfSignedPEM(t, "Test CA")
+	dir := t.TempDir()
+	path := filepath.Join(dir, "ca.crt")
+	if err := os.WriteFile(path, certPEM, 0644); err != nil {
+		t.Fatalf("write ca file: %v", err)
+	}
+
+	pool, err := LoadCACertPool(path)
+	if err != nil {
+		t.Fatalf("LoadCACertPool: %v", err)
+	}
+	if pool == nil {
+		t.Fatal("expected non-nil pool")
+	}
+}
+
+func TestLoadCACertPool_MissingFile(t *testing.T) {
+	if _, err := LoadCACertPool("/nonexistent/path/ca.crt"); err == nil {
+		t.Fatal("expected error for missing file")
+	}
+}
+
+func TestLoadCACertPool_InvalidPEM(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "bad.crt")
+	if err := os.WriteFile(path, []byte("not a cert"), 0644); err != nil {
+		t.Fatalf("write file: %v", err)
+	}
+	if _, err := LoadCACertPool(path); err == nil {
+		t.Fatal("expected error for invalid PEM")
+	}
+}
+
+func TestVerifyPeerCommonName(t *testing.T) {
+	_, cert := generateSelfSignedPEM(t, "SLAVE1")
+
+	t.Run("matches", func(t *testing.T) {
+		state := tls.ConnectionState{PeerCertificates: []*x509.Certificate{cert}}
+		if err := VerifyPeerCommonName(state, "SLAVE1"); err != nil {
+			t.Fatalf("expected match, got error: %v", err)
+		}
+	})
+
+	t.Run("mismatch", func(t *testing.T) {
+		state := tls.ConnectionState{PeerCertificates: []*x509.Certificate{cert}}
+		if err := VerifyPeerCommonName(state, "SLAVE2"); err == nil {
+			t.Fatal("expected error for CN mismatch")
+		}
+	})
+
+	t.Run("no peer cert", func(t *testing.T) {
+		state := tls.ConnectionState{}
+		if err := VerifyPeerCommonName(state, "SLAVE1"); err == nil {
+			t.Fatal("expected error when no peer certificate presented")
+		}
+	})
+}

--- a/setup.sh
+++ b/setup.sh
@@ -134,13 +134,35 @@ run_cleanup_mode() {
     exit 0
 }
 
+# build_san_extension turns a comma-separated list of hostnames/IPs into an
+# openssl "subjectAltName=..." extension line. Go's TLS client verification
+# rejects certs that rely on the legacy CN field for hostname matching, so
+# the master's server cert needs a real SAN covering however slaves reach it.
+build_san_extension() {
+    local input="$1"
+    local entries=() token trimmed
+    IFS=',' read -ra tokens <<< "${input}"
+    for token in "${tokens[@]}"; do
+        trimmed="$(printf '%s' "${token}" | tr -d '[:space:]')"
+        [ -z "${trimmed}" ] && continue
+        if printf '%s' "${trimmed}" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+$'; then
+            entries+=("IP:${trimmed}")
+        else
+            entries+=("DNS:${trimmed}")
+        fi
+    done
+    if [ "${#entries[@]}" -eq 0 ]; then
+        entries=("IP:127.0.0.1")
+    fi
+    printf 'subjectAltName=%s' "$(join_by ',' "${entries[@]}")"
+}
+
 generate_tls_certs() {
-    local site_name out_dir ca_cn server_cn client_cn org
+    local site_name out_dir ca_cn server_cn org
     site_name="${1:-${WEAVEFTPD_CERT_NAME:-WeaveFTPd}}"
     out_dir="${ROOT_DIR}/etc/certs"
     ca_cn="${site_name} Root CA"
     server_cn="${site_name} FTP"
-    client_cn="${site_name} Slave"
     org="${site_name}"
 
     show_banner
@@ -148,44 +170,52 @@ generate_tls_certs() {
     say "Site name: ${site_name}"
     say ""
 
+    local server_sans sanline
+    server_sans="$(prompt_default 'Master hostname/IP(s) reachable by slaves (comma-separated)' "${SETUP_MASTER_TLS_SANS:-${SETUP_PUBLIC_IP:-127.0.0.1}}")"
+    SETUP_MASTER_TLS_SANS="${server_sans}"
+    sanline="$(build_san_extension "${server_sans}")"
+
     mkdir -p "${out_dir}"
     (
         cd "${out_dir}"
 
+        # CA: 10-year root. Signs the master's server cert below, and (via
+        # generate_slave_cert) one client cert per slave for mTLS on the
+        # master-slave link.
         openssl ecparam -genkey -name secp384r1 -out ca.key
         openssl req -new -x509 -sha384 -days 3650 -key ca.key -out ca.crt \
-            -subj "/CN=${ca_cn}/O=${org}"
+            -subj "/CN=${ca_cn}/O=${org}" \
+            -addext "basicConstraints=critical,CA:TRUE" \
+            -addext "keyUsage=critical,keyCertSign,cRLSign"
 
+        cat > server.ext <<EOF
+basicConstraints=CA:FALSE
+keyUsage=digitalSignature,keyEncipherment
+extendedKeyUsage=serverAuth
+${sanline}
+EOF
         openssl ecparam -genkey -name secp384r1 -out server.key
         openssl req -new -sha384 -key server.key -out server.csr \
             -subj "/CN=${server_cn}/O=${org}"
         openssl x509 -req -sha384 -days 3650 -in server.csr \
-            -CA ca.crt -CAkey ca.key -CAcreateserial -out server.crt
+            -CA ca.crt -CAkey ca.key -CAcreateserial -out server.crt \
+            -extfile server.ext
 
-        openssl ecparam -genkey -name secp384r1 -out client.key
-        openssl req -new -sha384 -key client.key -out client.csr \
-            -subj "/CN=${client_cn}/O=${org}"
-        openssl x509 -req -sha384 -days 3650 -in client.csr \
-            -CA ca.crt -CAkey ca.key -CAcreateserial -out client.crt
-
-        rm -f *.csr *.srl
+        rm -f *.csr *.ext *.srl
     )
 
     say ""
     say "Certificates generated in ${out_dir}/"
     say ""
     say "  Site name:   ${site_name}"
-    say "  Issued by:   ${ca_cn}"
-    say "  Server cert: ${server_cn}"
-    say "  Slave cert:  ${client_cn}"
+    say "  Issued by:   ${ca_cn} (10-year root)"
+    say "  Server cert: ${server_cn} (SAN: ${server_sans})"
     say ""
     say "  ECDSA P-384 keys -> TLSv1.3 TLS_AES_256_GCM_SHA384"
     say ""
-    say "  ca.crt      - CA certificate"
+    say "  ca.crt      - CA certificate (trust this on every slave)"
     say "  server.crt  - Master/FTP certificate"
     say "  server.key  - Master/FTP private key"
-    say "  client.crt  - Slave certificate"
-    say "  client.key  - Slave private key"
     say ""
     say "Update etc/config.yml:"
     say "  tls_cert: ./etc/certs/server.crt"
@@ -195,6 +225,58 @@ generate_tls_certs() {
     say ""
     say "Note: tls_enabled only makes TLS available."
     say "      require_tls_control/data actually force secure FTP logins/transfers."
+    say ""
+    say "For mTLS on the master-slave link, generate a per-slave certificate with:"
+    say "  ./setup.sh slavecert <slave name>"
+}
+
+# generate_slave_cert issues one CA-signed client certificate for a single
+# slave, CN=<name>. The master checks that a connecting slave's presented
+# certificate CN matches the slave name it claims over the wire, so each
+# slave needs its own cert - never share one between slaves.
+generate_slave_cert() {
+    local slave_name="$1"
+    local site_name="${2:-${SETUP_CERT_NAME:-${WEAVEFTPD_CERT_NAME:-WeaveFTPd}}}"
+    local out_dir="${ROOT_DIR}/etc/certs"
+    local org="${site_name}"
+
+    if [ -z "${slave_name}" ]; then
+        say "Usage: ./setup.sh slavecert <slave name>"
+        return 1
+    fi
+
+    if [ ! -f "${out_dir}/ca.crt" ] || [ ! -f "${out_dir}/ca.key" ]; then
+        say_color "${C_YELLOW}" "No CA found in ${out_dir}; generating CA + server cert first."
+        generate_tls_certs "${site_name}"
+    fi
+
+    say ""
+    say "Generating slave client certificate for '${slave_name}' (CN must equal this slave's configured name)"
+
+    mkdir -p "${out_dir}"
+    (
+        cd "${out_dir}"
+        openssl ecparam -genkey -name secp384r1 -out "slave-${slave_name}.key"
+        openssl req -new -sha384 -key "slave-${slave_name}.key" -out "slave-${slave_name}.csr" \
+            -subj "/CN=${slave_name}/O=${org}"
+        cat > "slave-${slave_name}.ext" <<EOF
+basicConstraints=CA:FALSE
+keyUsage=digitalSignature
+extendedKeyUsage=clientAuth
+EOF
+        openssl x509 -req -sha384 -days 3650 -in "slave-${slave_name}.csr" \
+            -CA ca.crt -CAkey ca.key -CAcreateserial -out "slave-${slave_name}.crt" \
+            -extfile "slave-${slave_name}.ext"
+        rm -f "slave-${slave_name}.csr" "slave-${slave_name}.ext" *.srl
+    )
+
+    say ""
+    say "  slave-${slave_name}.crt / slave-${slave_name}.key generated in ${out_dir}/"
+    say "  Copy these plus ca.crt to this slave's etc/certs/ directory if it runs on a separate box,"
+    say "  then set (in that slave's slave: config block):"
+    say "    master_ca_cert: ./etc/certs/ca.crt"
+    say "    client_cert:    ./etc/certs/slave-${slave_name}.crt"
+    say "    client_key:     ./etc/certs/slave-${slave_name}.key"
 }
 
 bool_to_prompt_default() {
@@ -1077,6 +1159,84 @@ configure_sitebot_plugin_connections() {
     fi
 }
 
+# configure_master_slave_mtls prompts a fresh master install to either set up
+# mTLS for the master-slave link (recommended) or, if declined, register at
+# least one IP mask per slave so the link doesn't come up fail-closed.
+configure_master_slave_mtls() {
+    local cert_name="$1"
+    local daemon_config="etc/config.yml"
+
+    say ""
+    if prompt_yes_no "Configure mTLS for the master-slave link? (recommended)" "$(bool_to_prompt_default "${SETUP_SLAVE_MTLS:-true}")"; then
+        SETUP_SLAVE_MTLS="true"
+        if [ ! -f "etc/certs/ca.crt" ] || [ ! -f "etc/certs/server.crt" ]; then
+            generate_tls_certs "${cert_name}"
+        fi
+        replace_matching_line "${daemon_config}" '^  slave_ca_cert:' "  slave_ca_cert: \"./etc/certs/ca.crt\""
+
+        say ""
+        say "Add a client certificate for each slave that will connect to this master."
+        local mtls_slave_name
+        while prompt_yes_no "Add a slave certificate now?" "N"; do
+            mtls_slave_name="$(prompt_default "Slave name (must match that slave's configured name)" "SLAVE1")"
+            generate_slave_cert "${mtls_slave_name}" "${cert_name}"
+            say "Remember to securely copy slave-${mtls_slave_name}.crt, slave-${mtls_slave_name}.key, and ca.crt to that slave's etc/certs/ directory."
+        done
+    else
+        SETUP_SLAVE_MTLS="false"
+        say ""
+        say "Without mTLS, each slave name MUST have at least one IP/CIDR mask registered on the"
+        say "master, or its connection will be refused (fail closed)."
+        local mask_slave_name mask_value
+        mask_slave_name="$(prompt_default 'Slave name to register a mask for now (blank to skip)' '')"
+        while [ -n "${mask_slave_name}" ]; do
+            mask_value="$(prompt_default "Allowed IP/CIDR/wildcard for slave '${mask_slave_name}'" "127.0.0.1/32")"
+            mkdir -p "$(dirname "etc/slave_masks.txt")"
+            printf '%s %s\n' "${mask_slave_name}" "${mask_value}" >> "etc/slave_masks.txt"
+            say "Registered mask ${mask_value} for slave ${mask_slave_name} in etc/slave_masks.txt"
+            mask_slave_name="$(prompt_default 'Another slave name to register a mask for (blank to finish)' '')"
+        done
+    fi
+}
+
+# configure_slave_mtls prompts a fresh slave install to point at its mTLS
+# identity (CA + this slave's own client cert), or warns that the master
+# admin must register an IP mask for this slave name if mTLS isn't used.
+configure_slave_mtls() {
+    local slave_name="$1"
+    local daemon_config="etc/config.yml"
+    local ca_path client_cert_path client_key_path
+
+    say ""
+    if prompt_yes_no "Configure mTLS for the master-slave link? (recommended)" "$(bool_to_prompt_default "${SETUP_SLAVE_MTLS:-true}")"; then
+        SETUP_SLAVE_MTLS="true"
+        ca_path="$(prompt_default 'Path to the CA certificate (copied from the master)' "${SETUP_SLAVE_MASTER_CA:-./etc/certs/ca.crt}")"
+        client_cert_path="$(prompt_default "Path to this slave's client certificate" "${SETUP_SLAVE_CLIENT_CERT:-./etc/certs/slave-${slave_name}.crt}")"
+        client_key_path="$(prompt_default "Path to this slave's client private key" "${SETUP_SLAVE_CLIENT_KEY:-./etc/certs/slave-${slave_name}.key}")"
+        SETUP_SLAVE_MASTER_CA="${ca_path}"
+        SETUP_SLAVE_CLIENT_CERT="${client_cert_path}"
+        SETUP_SLAVE_CLIENT_KEY="${client_key_path}"
+
+        replace_matching_line "${daemon_config}" '^  master_ca_cert:' "  master_ca_cert: \"${ca_path}\""
+        replace_matching_line "${daemon_config}" '^  client_cert:' "  client_cert:   \"${client_cert_path}\""
+        replace_matching_line "${daemon_config}" '^  client_key:' "  client_key:    \"${client_key_path}\""
+
+        if [ ! -f "${ca_path}" ] || [ ! -f "${client_cert_path}" ] || [ ! -f "${client_key_path}" ]; then
+            say ""
+            say_color "${C_YELLOW}" "Note: one or more of those files don't exist yet on this box."
+            say "If this slave runs on a separate server from the master, run"
+            say "  ./setup.sh slavecert ${slave_name}"
+            say "on the master, then securely copy the resulting files here."
+        fi
+    else
+        SETUP_SLAVE_MTLS="false"
+        say ""
+        say "Without mTLS, the master admin must register an IP mask for this slave, e.g. on the master:"
+        say "  SITE SLAVE ${slave_name} ADDMASK <this slave's IP/CIDR>"
+        say "Otherwise the master will refuse this slave's connection (fail closed)."
+    fi
+}
+
 configure_daemon() {
     local daemon_config="etc/config.yml"
     local daemon_config_exists="false"
@@ -1238,6 +1398,12 @@ daemon_plugins=(autonuke dateddirs tvmaze imdb speedtest request releaseguard pr
         say "TLS certificates already exist in etc/certs; skipping generation."
     fi
 
+    if [ "${daemon_config_exists}" = "false" ] && [ "${daemon_mode}" = "master" ]; then
+        configure_master_slave_mtls "${cert_name}"
+    elif [ "${daemon_config_exists}" = "false" ] && [ "${daemon_mode}" = "slave" ]; then
+        configure_slave_mtls "${slave_name}"
+    fi
+
     print_plugin_summary \
         "Daemon plugin summary" \
         "$(join_by ', ' "${daemon_plugins[@]}")" \
@@ -1276,7 +1442,7 @@ configure_sitebot() {
     say "Configuring sitebot..."
     copy_if_missing "sitebot/etc/config.yml.example" "${sitebot_config}"
 
-    local irc_host irc_port irc_nick irc_user irc_realname irc_password irc_ssl sitebot_version
+    local irc_host irc_port irc_nick irc_user irc_realname irc_password irc_ssl irc_tls_verify irc_tls_ca_cert sitebot_version
     local ftp_host ftp_port ftp_user ftp_password ftp_tls ftp_insecure bnc_target_host bnc_target_port bnc_target_name rules_file
     local main_channel chat_channel spam_channel staff_channel foreign_channel archive_channel nuke_channel enabled_bool
     local main_key chat_key spam_key staff_key foreign_key archive_key nuke_key private_key
@@ -1293,6 +1459,15 @@ configure_sitebot() {
             irc_ssl="true"
         else
             irc_ssl="false"
+        fi
+        irc_tls_ca_cert=""
+        if [ "${irc_ssl}" = "true" ]; then
+            irc_tls_verify="$(prompt_default 'IRC TLS verification (strict/custom/insecure)' "${SETUP_IRC_TLS_VERIFY:-strict}")"
+            if [ "${irc_tls_verify}" = "custom" ]; then
+                irc_tls_ca_cert="$(prompt_default 'Path to IRC server CA certificate' "${SETUP_IRC_TLS_CA_CERT:-./etc/certs/irc-ca.crt}")"
+            fi
+        else
+            irc_tls_verify="${SETUP_IRC_TLS_VERIFY:-strict}"
         fi
         ftp_host="$(prompt_default 'Sitebot FTP host for plugins' "${SETUP_PLUGIN_FTP_HOST:-127.0.0.1}")"
         ftp_port="$(prompt_default 'Sitebot FTP port for plugins' "${SETUP_PLUGIN_FTP_PORT:-21212}")"
@@ -1338,6 +1513,8 @@ configure_sitebot() {
         irc_realname="${SETUP_IRC_REALNAME:-GoSitebot v${sitebot_version}}"
         irc_password="${SETUP_IRC_PASSWORD:-changeme}"
         irc_ssl="${SETUP_IRC_SSL:-true}"
+        irc_tls_verify="${SETUP_IRC_TLS_VERIFY:-strict}"
+        irc_tls_ca_cert="${SETUP_IRC_TLS_CA_CERT:-}"
         ftp_host="${SETUP_PLUGIN_FTP_HOST:-127.0.0.1}"
         ftp_port="${SETUP_PLUGIN_FTP_PORT:-21212}"
         ftp_user="${SETUP_PLUGIN_FTP_USER:-weaveftpd}"
@@ -1373,6 +1550,8 @@ configure_sitebot() {
     SETUP_IRC_REALNAME="${irc_realname}"
     SETUP_IRC_PASSWORD="${irc_password}"
     SETUP_IRC_SSL="${irc_ssl}"
+    SETUP_IRC_TLS_VERIFY="${irc_tls_verify}"
+    SETUP_IRC_TLS_CA_CERT="${irc_tls_ca_cert}"
     SETUP_PLUGIN_FTP_HOST="${ftp_host}"
     SETUP_PLUGIN_FTP_PORT="${ftp_port}"
     SETUP_PLUGIN_FTP_USER="${ftp_user}"
@@ -1410,6 +1589,8 @@ configure_sitebot() {
         set_sitebot_scalar "${sitebot_config}" "realname" "\"${irc_realname}\""
         set_sitebot_scalar "${sitebot_config}" "password" "\"${irc_password}\""
         set_sitebot_scalar "${sitebot_config}" "ssl" "${irc_ssl}"
+        set_sitebot_scalar "${sitebot_config}" "tls_verify" "\"${irc_tls_verify}\""
+        set_sitebot_scalar "${sitebot_config}" "tls_ca_cert" "\"${irc_tls_ca_cert}\""
         replace_matching_line "${sitebot_config}" '^version:' "version:       \"${sitebot_version}\""
         replace_matching_line "${sitebot_config}" '^event_fifo:' "event_fifo: \"${fifo_path}\""
 
@@ -2573,7 +2754,8 @@ show_usage() {
     say "  ./setup.sh install   Run guided install/config setup"
     say "  ./setup.sh build     Build daemon and sitebot only"
     say "  ./setup.sh update    Pull the latest Git changes with git pull --ff-only"
-    say "  ./setup.sh certs     Generate fresh TLS certificates"
+    say "  ./setup.sh certs     Generate fresh TLS certificates (CA + master server cert)"
+    say "  ./setup.sh slavecert <name>  Generate an mTLS client cert for one slave"
     say "  ./setup.sh import-glftpd [root]  Import users/groups from a glFTPD tree"
     say "  ./setup.sh import-drftpd3 [root] Import users/groups from a DrFTPD v3 tree"
     say "  ./setup.sh import-drftpd4 [root] Import users/groups from a DrFTPD v4 tree"
@@ -2586,7 +2768,8 @@ show_usage() {
     say "  - 'install' loads ${STATE_FILE} as defaults when you allow it."
     say "  - 'build' just runs the daemon and sitebot build scripts."
     say "  - 'update' runs git pull --ff-only from the repository root."
-    say "  - 'certs' writes CA, server, and slave certs into ./etc/certs."
+    say "  - 'certs' writes a CA + master server cert into ./etc/certs."
+    say "  - 'slavecert' writes one CA-signed client cert (CN=<name>) for mTLS on the master-slave link."
     say "  - 'import-glftpd' stages a copy of /glftpd-style account files, backs up current WeaveFTPd account data, then converts passwd/group/user/group files."
     say "  - 'import-drftpd3' stages userdata/users/javabeans, derives groups, merges into WeaveFTPd, and requires siteop password resets afterward."
     say "  - 'import-drftpd4' stages DrFTPD v4 users/groups JSON, preserves supported password formats when possible, and merges into WeaveFTPd."
@@ -2619,6 +2802,11 @@ case "${1:-help}" in
     certs|--certs)
         ensure_script_permissions
         generate_tls_certs "${2:-${WEAVEFTPD_CERT_NAME:-WeaveFTPd}}"
+        exit 0
+        ;;
+    slavecert|--slavecert)
+        ensure_script_permissions
+        generate_slave_cert "${2:-}" "${3:-${WEAVEFTPD_CERT_NAME:-WeaveFTPd}}"
         exit 0
         ;;
     build|--build)

--- a/sitebot/etc/config.yml.example
+++ b/sitebot/etc/config.yml.example
@@ -28,6 +28,14 @@ irc:
   realname: "GoSitebot"
   password: "changeme"
   ssl: true
+  # Server-certificate verification for the IRC connection (only relevant
+  # when ssl: true):
+  #   strict   - verify against the system trust store (default; use this
+  #              for public IRC networks with globally-trusted certs)
+  #   custom   - verify against tls_ca_cert below (self-hosted/private IRCd)
+  #   insecure - disable verification entirely (not recommended)
+  tls_verify: "strict"
+  tls_ca_cert: ""   # required when tls_verify: custom, e.g. "./etc/certs/irc-ca.crt"
   nickserv:
     enabled: false
     service: "NickServ"

--- a/sitebot/internal/bot/bot.go
+++ b/sitebot/internal/bot/bot.go
@@ -60,6 +60,8 @@ func (b *Bot) Start() error {
 		b.Config.IRC.Host, b.Config.IRC.Port, b.Config.IRC.Nick, len(uniqueChannels(b.Config)))
 	b.IRC = irc.NewBot(b.Config.IRC.Host, b.Config.IRC.Port, b.Config.IRC.Nick, b.Config.IRC.User, b.Config.IRC.RealName)
 	b.IRC.SSL = b.Config.IRC.SSL
+	b.IRC.TLSVerify = b.Config.IRC.TLSVerify
+	b.IRC.TLSCACert = b.Config.IRC.TLSCACert
 	b.IRC.Password = b.Config.IRC.Password
 	b.IRC.Debug = b.Debug
 	if err := b.IRC.Connect(); err != nil {

--- a/sitebot/internal/bot/config.go
+++ b/sitebot/internal/bot/config.go
@@ -37,9 +37,13 @@ type HelpConfig struct {
 }
 
 type IRCConfig struct {
-	Host          string         `yaml:"host"`
-	Port          int            `yaml:"port"`
-	SSL           bool           `yaml:"ssl"`
+	Host string `yaml:"host"`
+	Port int    `yaml:"port"`
+	SSL  bool   `yaml:"ssl"`
+	// TLSVerify: "strict" (default) verifies against the system trust store,
+	// "custom" verifies against TLSCACert, "insecure" disables verification.
+	TLSVerify     string         `yaml:"tls_verify"`
+	TLSCACert     string         `yaml:"tls_ca_cert"`
 	Nick          string         `yaml:"nick"`
 	User          string         `yaml:"user"`
 	RealName      string         `yaml:"realname"`

--- a/sitebot/internal/irc/irc.go
+++ b/sitebot/internal/irc/irc.go
@@ -2,9 +2,11 @@ package irc
 
 import (
 	"crypto/tls"
+	"crypto/x509"
 	"fmt"
 	"log"
 	"net"
+	"os"
 	"strconv"
 	"strings"
 	"sync"
@@ -15,9 +17,15 @@ import (
 const maxIRCLineBytes = 510
 
 type Bot struct {
-	Host         string
-	Port         int
-	SSL          bool
+	Host string
+	Port int
+	SSL  bool
+	// TLSVerify controls server-certificate verification when SSL is true:
+	// "strict" (default/empty) verifies against the system trust store,
+	// "custom" verifies against TLSCACert, "insecure" explicitly disables
+	// verification. Anything else falls back to "strict".
+	TLSVerify    string
+	TLSCACert    string
 	Nick         string
 	User         string
 	RealName     string
@@ -61,7 +69,12 @@ func (b *Bot) Connect() error {
 	var conn net.Conn
 	var err error
 	if b.SSL {
-		conn, err = tls.Dial("tcp", addr, &tls.Config{InsecureSkipVerify: true})
+		var tlsCfg *tls.Config
+		tlsCfg, err = b.buildTLSConfig()
+		if err != nil {
+			return err
+		}
+		conn, err = tls.Dial("tcp", addr, tlsCfg)
 	} else {
 		conn, err = net.Dial("tcp", addr)
 	}
@@ -79,6 +92,46 @@ func (b *Bot) Connect() error {
 		log.Printf("[IRC] Connected to %s:%d", b.Host, b.Port)
 	}
 	return nil
+}
+
+// buildTLSConfig builds the TLS client config for the IRC connection based on
+// b.TLSVerify. Verification defaults to "strict" (system trust store) -
+// InsecureSkipVerify is now an explicit opt-in ("insecure"), not the default.
+func (b *Bot) buildTLSConfig() (*tls.Config, error) {
+	cfg := &tls.Config{ServerName: b.Host}
+	switch strings.ToLower(strings.TrimSpace(b.TLSVerify)) {
+	case "", "strict":
+		// default: verify against the system trust store
+	case "custom":
+		pool, err := loadCACertPool(b.TLSCACert)
+		if err != nil {
+			return nil, fmt.Errorf("failed to load irc tls_ca_cert: %w", err)
+		}
+		cfg.RootCAs = pool
+	case "insecure":
+		cfg.InsecureSkipVerify = true
+	default:
+		return nil, fmt.Errorf("invalid irc tls_verify %q (expected strict, custom, or insecure)", b.TLSVerify)
+	}
+	return cfg, nil
+}
+
+// loadCACertPool reads a PEM-encoded CA certificate (or bundle) from path.
+// Kept local to this package rather than shared with the main weaveftpd
+// module: sitebot is a separate Go module with no dependency on it.
+func loadCACertPool(path string) (*x509.CertPool, error) {
+	if strings.TrimSpace(path) == "" {
+		return nil, fmt.Errorf("tls_ca_cert path is required when tls_verify is \"custom\"")
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read CA cert %q: %w", path, err)
+	}
+	pool := x509.NewCertPool()
+	if !pool.AppendCertsFromPEM(data) {
+		return nil, fmt.Errorf("no valid certificates found in %q", path)
+	}
+	return pool, nil
 }
 
 func (b *Bot) SendRaw(cmd string) error {

--- a/sitebot/internal/irc/irc_tls_test.go
+++ b/sitebot/internal/irc/irc_tls_test.go
@@ -1,0 +1,96 @@
+package irc
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"math/big"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestBuildTLSConfigDefaultsToStrict(t *testing.T) {
+	b := &Bot{Host: "irc.example.net"}
+	cfg, err := b.buildTLSConfig()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg.InsecureSkipVerify {
+		t.Fatal("expected verification enabled by default (no InsecureSkipVerify)")
+	}
+	if cfg.RootCAs != nil {
+		t.Fatal("expected no custom RootCAs in strict mode")
+	}
+	if cfg.ServerName != "irc.example.net" {
+		t.Fatalf("expected ServerName to be set, got %q", cfg.ServerName)
+	}
+}
+
+func TestBuildTLSConfigInsecure(t *testing.T) {
+	b := &Bot{Host: "irc.example.net", TLSVerify: "insecure"}
+	cfg, err := b.buildTLSConfig()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !cfg.InsecureSkipVerify {
+		t.Fatal("expected InsecureSkipVerify=true for explicit insecure opt-out")
+	}
+}
+
+func TestBuildTLSConfigCustomCA(t *testing.T) {
+	dir := t.TempDir()
+	certPath := filepath.Join(dir, "ca.crt")
+	if err := os.WriteFile(certPath, selfSignedTestCertPEM(t), 0644); err != nil {
+		t.Fatalf("write ca file: %v", err)
+	}
+
+	b := &Bot{Host: "irc.example.net", TLSVerify: "custom", TLSCACert: certPath}
+	cfg, err := b.buildTLSConfig()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg.InsecureSkipVerify {
+		t.Fatal("expected verification enabled in custom mode")
+	}
+	if cfg.RootCAs == nil {
+		t.Fatal("expected RootCAs to be populated in custom mode")
+	}
+}
+
+func TestBuildTLSConfigCustomRequiresCACert(t *testing.T) {
+	b := &Bot{Host: "irc.example.net", TLSVerify: "custom"}
+	if _, err := b.buildTLSConfig(); err == nil {
+		t.Fatal("expected error when tls_verify=custom but tls_ca_cert is empty")
+	}
+}
+
+func TestBuildTLSConfigInvalidVerifyMode(t *testing.T) {
+	b := &Bot{Host: "irc.example.net", TLSVerify: "bogus"}
+	if _, err := b.buildTLSConfig(); err == nil {
+		t.Fatal("expected error for unrecognized tls_verify value")
+	}
+}
+
+func selfSignedTestCertPEM(t *testing.T) []byte {
+	t.Helper()
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("generate key: %v", err)
+	}
+	tmpl := &x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		Subject:      pkix.Name{CommonName: "Test IRC CA"},
+		NotBefore:    time.Now().Add(-time.Hour),
+		NotAfter:     time.Now().Add(time.Hour),
+	}
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, &key.PublicKey, key)
+	if err != nil {
+		t.Fatalf("create cert: %v", err)
+	}
+	return pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der})
+}


### PR DESCRIPTION
Remove InsecureSkipVerify where it doesn't make sense to skip

No auth and no allowlist on the master slave protocol is insecure, to mitigate that we have:
* Added a master <-> slave mTLS option, generate certs via the setup script
  * Fallback if you don't want mTLS (you should though) is a ip mask allowlist similar to drftpd's
* Sitebot: allow to trust global certs in your system, or inject your own ca-bundle