### PR TITLE
Fix leaking goroutine on slave reconnect (remerge)

### DIFF
--- a/internal/master/remote_slave.go
+++ b/internal/master/remote_slave.go
@@ -523,10 +523,17 @@ func (rs *RemoteSlave) SetOffline(reason string) {
 		rs.onOffline(rs.name)
 	}
 
-	// [Added] Instantly unblocks any FetchResponse calls waiting for data from this dead slave
+	// [Added] Instantly unblocks any FetchResponse calls waiting for data from this dead slave.
+	// A nil send (not a close) is used deliberately: routeResponse can still be delivering a
+	// late response to this same channel from the Run() read-loop goroutine concurrently with
+	// this shutdown path, and sending on a closed channel panics regardless of select/default,
+	// crashing the whole daemon. FetchResponse already treats a nil resp as "connection closed".
 	rs.pendingCmds.Range(func(key, value interface{}) bool {
 		if ch, ok := value.(chan interface{}); ok {
-			close(ch)
+			select {
+			case ch <- nil:
+			default:
+			}
 		}
 		return true
 	})

--- a/internal/master/remote_slave.go
+++ b/internal/master/remote_slave.go
@@ -30,6 +30,7 @@ type RemoteSlave struct {
 	commandNotify  chan struct{}
 	remergeQueue   chan *protocol.AsyncResponseRemerge
 	remergeDrained chan struct{}
+	remergeStop    chan struct{} // closed on SetOffline to stop runRemergeQueue without racing enqueueRemerge's send
 
 	// State
 	online            atomic.Bool
@@ -76,6 +77,7 @@ func NewRemoteSlave(name string, conn net.Conn, stream *protocol.ObjectStream, h
 		commandNotify:    make(chan struct{}, 256),
 		remergeQueue:     make(chan *protocol.AsyncResponseRemerge, 512),
 		remergeDrained:   make(chan struct{}, 1),
+		remergeStop:      make(chan struct{}),
 		properties:       make(map[string]string),
 		heartbeatTimeout: heartbeatTimeout,
 	}
@@ -386,22 +388,30 @@ func (rs *RemoteSlave) Run(masterSlaveManager *SlaveManager) {
 }
 
 func (rs *RemoteSlave) runRemergeQueue(masterSlaveManager *SlaveManager) {
-	for resp := range rs.remergeQueue {
-		if resp == nil {
-			continue
-		}
-		masterSlaveManager.ProcessRemerge(rs, resp)
-		depth := rs.remergeQueueDepth.Add(-1)
-		if depth < 0 {
-			rs.remergeQueueDepth.Store(0)
-			depth = 0
-		}
-		rs.applyRemergeFlowControl(masterSlaveManager, depth)
-		if depth == 0 {
-			select {
-			case rs.remergeDrained <- struct{}{}:
-			default:
+	// Selects on remergeStop (closed by SetOffline) instead of ranging over
+	// remergeQueue, since enqueueRemerge may still be sending concurrently on
+	// disconnect and closing remergeQueue itself would risk a send-on-closed-channel panic.
+	for {
+		select {
+		case resp := <-rs.remergeQueue:
+			if resp == nil {
+				continue
 			}
+			masterSlaveManager.ProcessRemerge(rs, resp)
+			depth := rs.remergeQueueDepth.Add(-1)
+			if depth < 0 {
+				rs.remergeQueueDepth.Store(0)
+				depth = 0
+			}
+			rs.applyRemergeFlowControl(masterSlaveManager, depth)
+			if depth == 0 {
+				select {
+				case rs.remergeDrained <- struct{}{}:
+				default:
+				}
+			}
+		case <-rs.remergeStop:
+			return
 		}
 	}
 }
@@ -503,6 +513,9 @@ func (rs *RemoteSlave) SetOffline(reason string) {
 	rs.available.Store(false)
 	rs.clearActiveRemerge("")
 	rs.remergeQueueDepth.Store(0)
+	if rs.remergeStop != nil {
+		close(rs.remergeStop)
+	}
 	if rs.conn != nil {
 		rs.conn.Close()
 	}

--- a/internal/master/remote_slave_test.go
+++ b/internal/master/remote_slave_test.go
@@ -1,6 +1,7 @@
 package master
 
 import (
+	"sync"
 	"testing"
 	"time"
 
@@ -91,4 +92,83 @@ func TestWaitForRemergeDrainReturnsAfterQueueClears(t *testing.T) {
 	if err := rs.WaitForRemergeDrain(200 * time.Millisecond); err != nil {
 		t.Fatalf("WaitForRemergeDrain returned error: %v", err)
 	}
+}
+
+// TestSetOfflineDoesNotPanicOnConcurrentRouteResponse guards against a shutdown
+// racing with Run()'s read loop: SetOffline must never close a pendingCmds
+// channel while routeResponse is still sending on it, since that panics
+// regardless of the select/default guard on the send side.
+func TestSetOfflineDoesNotPanicOnConcurrentRouteResponse(t *testing.T) {
+	rs := &RemoteSlave{
+		commandNotify:    make(chan struct{}, 1),
+		remergeQueue:     make(chan *protocol.AsyncResponseRemerge, 1),
+		remergeDrained:   make(chan struct{}, 1),
+		remergeStop:      make(chan struct{}),
+		heartbeatTimeout: time.Second,
+	}
+	rs.online.Store(true)
+	rs.pendingCmds.Store("01", make(chan interface{}, 1))
+
+	var wg sync.WaitGroup
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		for i := 0; i < 1000; i++ {
+			rs.routeResponse("01", &protocol.AsyncResponse{Index: "01"})
+		}
+	}()
+	go func() {
+		defer wg.Done()
+		rs.SetOffline("concurrent shutdown")
+	}()
+	wg.Wait()
+}
+
+// TestRunRemergeQueueExitsOnSetOffline verifies runRemergeQueue's goroutine
+// actually terminates once SetOffline closes remergeStop, instead of
+// leaking forever waiting on an unclosed remergeQueue.
+func TestRunRemergeQueueExitsOnSetOffline(t *testing.T) {
+	rs := &RemoteSlave{
+		commandNotify:    make(chan struct{}, 1),
+		remergeQueue:     make(chan *protocol.AsyncResponseRemerge, 1),
+		remergeDrained:   make(chan struct{}, 1),
+		remergeStop:      make(chan struct{}),
+		heartbeatTimeout: time.Second,
+	}
+	rs.online.Store(true)
+
+	done := make(chan struct{})
+	go func() {
+		rs.runRemergeQueue(nil)
+		close(done)
+	}()
+
+	rs.SetOffline("shutdown")
+
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("runRemergeQueue goroutine leaked: did not exit after SetOffline")
+	}
+}
+
+// TestSetOfflineIsIdempotent verifies the CAS guard makes a second SetOffline
+// call a no-op, so it can't double-close remergeStop (which would panic) or
+// re-run shutdown side effects.
+func TestSetOfflineIsIdempotent(t *testing.T) {
+	rs := &RemoteSlave{
+		commandNotify:    make(chan struct{}, 1),
+		remergeQueue:     make(chan *protocol.AsyncResponseRemerge, 1),
+		remergeDrained:   make(chan struct{}, 1),
+		remergeStop:      make(chan struct{}),
+		heartbeatTimeout: time.Second,
+	}
+	rs.online.Store(true)
+
+	rs.SetOffline("first")
+	if rs.IsOnline() {
+		t.Fatalf("expected slave offline after first SetOffline call")
+	}
+
+	rs.SetOffline("second")
 }


### PR DESCRIPTION
Without the fix this goroutine would range forever on the never-closed channel. This fix allows runRemergeQueue to exit promptly on SetOffline